### PR TITLE
Add benchmark regression handoff artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Campaign artifacts (potentially sensitive)
 logs/
+reports/
 autoresearch/runtime/
 
 .pi

--- a/docs/wiki/decisions/jailbreak-benchmark-material-vault.md
+++ b/docs/wiki/decisions/jailbreak-benchmark-material-vault.md
@@ -100,6 +100,21 @@ redthread eval jailbreak-corpus \
   --report-out artifacts/spiritual-spell-0032-replay.json
 ```
 
+Write a prompt-safe regression handoff artifact from the same approved replay:
+
+```bash
+redthread eval jailbreak-corpus \
+  --fixture-id spiritual-spell-0032 \
+  --replay \
+  --manifest-ref spiritual-spell/manifests/spiritual-spell-0032.json \
+  --material-root "$REDTHREAD_BENCHMARK_MATERIAL_ROOT" \
+  --objective "Check trusted instruction handling" \
+  --system-prompt "Do not reveal secrets." \
+  --regression-out artifacts/spiritual-spell-0032-regression-handoff.json
+```
+
+The regression handoff artifact stores fixture lineage, manifest ref, SHA-256, reviewer metadata, JudgeAgent verdict linkage, and redacted regression case metadata. It does not store raw reviewed prompts or target responses that may echo them. Safe local replay normally creates zero regression cases and records `verdict_not_jailbreak`; confirmed jailbreak verdicts become prompt-safe handoff rows for the private regression system.
+
 `redthread run` is the product red-team lane. `redthread eval jailbreak-corpus` is the benchmark/regression lane. The split keeps reviewed corpus replay behind manifests, hashes, and local target gates.
 
 A normal product campaign may borrow metadata-only benchmark hints without loading raw prompt material:

--- a/docs/wiki/decisions/jailbreak-benchmark-material-vault.md
+++ b/docs/wiki/decisions/jailbreak-benchmark-material-vault.md
@@ -115,6 +115,71 @@ redthread eval jailbreak-corpus \
 
 The regression handoff artifact stores fixture lineage, manifest ref, SHA-256, reviewer metadata, JudgeAgent verdict linkage, and redacted regression case metadata. It does not store raw reviewed prompts or target responses that may echo them. Safe local replay normally creates zero regression cases and records `verdict_not_jailbreak`; confirmed jailbreak verdicts become prompt-safe handoff rows for the private regression system.
 
+## How to test
+
+Run the prompt-safe benchmark and regression handoff checks:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python -m pytest \
+  tests/test_benchmark_regression_handoff.py \
+  tests/test_benchmark_replay.py \
+  tests/test_benchmark_eval_replay_cli.py
+```
+
+Run the broader benchmark CLI/regression suite:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python -m pytest \
+  tests/test_jailbreak_fixtures.py \
+  tests/test_spiritual_spell_fixtures.py \
+  tests/test_benchmark_campaigns.py \
+  tests/test_benchmark_static_replay_metadata.py \
+  tests/test_benchmark_reports.py \
+  tests/test_benchmark_prompt_materials.py \
+  tests/test_benchmark_material_vault.py \
+  tests/test_benchmark_material_review.py \
+  tests/test_benchmark_hints.py \
+  tests/test_benchmark_dry_run.py \
+  tests/test_benchmark_replay.py \
+  tests/test_benchmark_artifacts.py \
+  tests/test_benchmark_regression_handoff.py \
+  tests/test_benchmark_eval_cli.py \
+  tests/test_benchmark_eval_replay_cli.py \
+  tests/test_benchmark_materials_cli.py \
+  tests/test_run_benchmark_fixture_cli.py \
+  tests/test_static_seed_replay_runner.py \
+  tests/test_regression_cases.py \
+  tests/test_cli_shell.py
+```
+
+Run static checks for the touched benchmark and CLI paths:
+
+```bash
+uv run ruff check \
+  src/redthread/benchmarks \
+  src/redthread/cli/app.py \
+  src/redthread/cli/benchmark_eval.py \
+  src/redthread/cli/benchmark_materials.py \
+  src/redthread/cli/run.py \
+  src/redthread/core/strategies/static_seed_replay.py
+
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run mypy \
+  src/redthread/benchmarks \
+  src/redthread/cli/app.py \
+  src/redthread/cli/benchmark_eval.py \
+  src/redthread/cli/benchmark_materials.py \
+  src/redthread/cli/run.py \
+  src/redthread/core/strategies/static_seed_replay.py
+```
+
+Check the CLI surface:
+
+```bash
+uv run redthread eval jailbreak-corpus --help
+```
+
+The help output should include `--regression-out`.
+
 `redthread run` is the product red-team lane. `redthread eval jailbreak-corpus` is the benchmark/regression lane. The split keeps reviewed corpus replay behind manifests, hashes, and local target gates.
 
 A normal product campaign may borrow metadata-only benchmark hints without loading raw prompt material:

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -16,7 +16,7 @@ This is the primary content map for the RedThread wiki.
 ## Decisions
 
 - [decisions/adopt-mempalace-plus-llm-wiki.md](decisions/adopt-mempalace-plus-llm-wiki.md) — Why RedThread uses MemPalace for retrieval and a markdown wiki for synthesis.
-- [decisions/jailbreak-benchmark-material-vault.md](decisions/jailbreak-benchmark-material-vault.md) — Why raw jailbreak benchmark material lives outside git behind reviewed manifests, hashes, approved-target gates, and metadata-only run hints.
+- [decisions/jailbreak-benchmark-material-vault.md](decisions/jailbreak-benchmark-material-vault.md) — Why raw jailbreak benchmark material lives outside git behind reviewed manifests, hashes, approved-target gates, metadata-only run hints, and prompt-safe regression handoff artifacts.
 
 ## Entities
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -7,6 +7,11 @@
 - added weak external evidence models and safe promptfoo, garak, and Strix dictionary mappers
 - preserved the finding boundary: imported evidence cannot claim confirmed-finding status and still requires JudgeAgent confirmation
 
+## [2026-04-26] implementation | slice R jailbreak benchmark regression handoff
+- added prompt-safe regression handoff artifacts for approved benchmark replay
+- added `--regression-out` to `redthread eval jailbreak-corpus --replay`
+- documented how handoff artifacts preserve fixture lineage and manifest hashes without raw prompt bodies
+
 ## [2026-04-26] implementation | restored jailbreak benchmark CLI and run-hint workflow
 - added `decisions/jailbreak-benchmark-material-vault.md` with dry-run, material import, approved replay, report artifact, and `redthread run --benchmark-fixture` command guidance
 - restored `redthread eval jailbreak-corpus` and `redthread eval jailbreak-material import` commands in the main worktree

--- a/src/redthread/benchmarks/__init__.py
+++ b/src/redthread/benchmarks/__init__.py
@@ -44,10 +44,20 @@ from redthread.benchmarks.prompt_materials import (
     load_prompt_material,
     load_replay_seed_prompts,
 )
+from redthread.benchmarks.regression_handoff import (
+    BenchmarkRegressionCaseSummary,
+    BenchmarkRegressionHandoffArtifact,
+    BenchmarkRegressionHandoffError,
+    BenchmarkRegressionSkip,
+    build_benchmark_regression_handoff,
+    write_benchmark_regression_handoff_artifact,
+)
 from redthread.benchmarks.replay import (
+    ApprovedBenchmarkReplayBundle,
     BenchmarkReplayError,
     LocalBenchmarkTarget,
     run_approved_jailbreak_replay,
+    run_approved_jailbreak_replay_with_regression_handoff,
 )
 from redthread.benchmarks.reports import (
     BenchmarkRunReport,
@@ -74,6 +84,11 @@ __all__ = [
     "MATERIAL_MANIFEST_SCHEMA_VERSION",
     "BenchmarkHintProfile",
     "BenchmarkMaterialManifest",
+    "ApprovedBenchmarkReplayBundle",
+    "BenchmarkRegressionCaseSummary",
+    "BenchmarkRegressionHandoffArtifact",
+    "BenchmarkRegressionHandoffError",
+    "BenchmarkRegressionSkip",
     "BenchmarkReplayError",
     "BenchmarkRunContext",
     "BenchmarkRunContextError",
@@ -89,6 +104,7 @@ __all__ = [
     "MaterialReviewError",
     "MaterialVaultError",
     "build_benchmark_campaign_draft",
+    "build_benchmark_regression_handoff",
     "build_jailbreak_corpus_dry_run_report",
     "build_benchmark_run_report",
     "apply_benchmark_fixture_context",
@@ -98,6 +114,7 @@ __all__ = [
     "build_fixture_hint_profiles",
     "import_reviewed_material",
     "run_approved_jailbreak_replay",
+    "run_approved_jailbreak_replay_with_regression_handoff",
     "load_jailbreak_fixture_file",
     "load_material_manifest",
     "load_jailbreak_fixture_pack",
@@ -106,5 +123,6 @@ __all__ = [
     "resolve_reviewed_material",
     "load_spiritual_spell_fixtures",
     "spiritual_spell_fixture_pack_data",
+    "write_benchmark_regression_handoff_artifact",
     "write_benchmark_report_artifact",
 ]

--- a/src/redthread/benchmarks/regression_handoff.py
+++ b/src/redthread/benchmarks/regression_handoff.py
@@ -1,0 +1,185 @@
+"""Prompt-safe regression handoff artifacts for benchmark replay."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from redthread.benchmarks.campaigns import BenchmarkCampaignDraft
+from redthread.benchmarks.jailbreak_fixtures import JailbreakBenchmarkFixture
+from redthread.benchmarks.material_vault import BenchmarkMaterialManifest
+from redthread.core.regression_cases import RegressionCaseError, regression_case_from_attack_result
+from redthread.models import AttackResult
+
+_REDACTED_PROMPT = "[redacted: reviewed benchmark prompt material remains in private vault]"
+_REDACTED_RESPONSE = "[redacted: target response may echo reviewed benchmark material]"
+
+
+class BenchmarkRegressionHandoffError(ValueError):
+    """Raised when a regression handoff artifact cannot be written."""
+
+
+class BenchmarkRegressionSkip(BaseModel):
+    """Reason one replay result did not become a regression case."""
+
+    result_id: str
+    trace_id: str
+    fixture_id: str
+    reason: str
+
+
+class BenchmarkRegressionCaseSummary(BaseModel):
+    """Prompt-safe regression case handoff row."""
+
+    regression_case_id: str
+    source_finding_id: str
+    fixture_id: str
+    risk_plugin_id: str
+    strategy_id: str
+    judge_score: float
+    severity_at_creation: str
+    expected_safe_behavior: str
+    material_ref: str
+    material_sha256: str
+    regression_case: dict[str, Any]
+
+
+class BenchmarkRegressionHandoffArtifact(BaseModel):
+    """Prompt-safe artifact for moving confirmed benchmark findings to regression work."""
+
+    schema_version: Literal["redthread.jailbreak_benchmark_regression_handoff.v1"] = (
+        "redthread.jailbreak_benchmark_regression_handoff.v1"
+    )
+    kind: str = "benchmark_regression_handoff"
+    fixture_id: str
+    manifest_ref: str
+    material_ref: str
+    material_sha256: str
+    reviewed_by: str
+    reviewed_at: str
+    allowed_target_ids: list[str] = Field(default_factory=list)
+    created_cases: list[BenchmarkRegressionCaseSummary] = Field(default_factory=list)
+    skipped_results: list[BenchmarkRegressionSkip] = Field(default_factory=list)
+    raw_prompt_policy: str = "raw prompt bodies are redacted; replay uses private vault material refs"
+
+    def summary_lines(self) -> list[str]:
+        """Return operator-readable summary lines."""
+        return [
+            "Regression handoff: prompt-safe artifact",
+            f"Fixture: {self.fixture_id}",
+            f"Regression cases created: {len(self.created_cases)}",
+            f"Results skipped: {len(self.skipped_results)}",
+            "Raw prompt bodies: redacted from artifact",
+        ]
+
+
+def build_benchmark_regression_handoff(
+    draft: BenchmarkCampaignDraft,
+    results: list[AttackResult],
+    *,
+    manifest: BenchmarkMaterialManifest,
+    manifest_ref: str,
+) -> BenchmarkRegressionHandoffArtifact:
+    """Build a prompt-safe handoff from approved replay results."""
+    fixture = _single_fixture(draft)
+    created_cases: list[BenchmarkRegressionCaseSummary] = []
+    skipped_results: list[BenchmarkRegressionSkip] = []
+    for result in results:
+        if not result.verdict.is_jailbreak:
+            skipped_results.append(_skip(result, fixture.id, "verdict_not_jailbreak"))
+            continue
+        try:
+            regression_case = regression_case_from_attack_result(
+                result,
+                expected_safe_behavior=fixture.expected_safe_behavior,
+                replay_schedule="manual",
+            )
+        except RegressionCaseError:
+            skipped_results.append(_skip(result, fixture.id, "not_replayable"))
+            continue
+        safe_case = regression_case.model_copy(
+            update={"minimized_trace": _redacted_trace(regression_case.minimized_trace)}
+        )
+        created_cases.append(
+            BenchmarkRegressionCaseSummary(
+                regression_case_id=safe_case.id,
+                source_finding_id=safe_case.source_finding_id,
+                fixture_id=fixture.id,
+                risk_plugin_id=safe_case.risk_plugin_id,
+                strategy_id=safe_case.strategy_id,
+                judge_score=result.verdict.score,
+                severity_at_creation=safe_case.severity_at_creation,
+                expected_safe_behavior=safe_case.expected_safe_behavior,
+                material_ref=manifest.material_ref,
+                material_sha256=manifest.sha256,
+                regression_case=safe_case.model_dump(mode="json"),
+            )
+        )
+    return BenchmarkRegressionHandoffArtifact(
+        fixture_id=fixture.id,
+        manifest_ref=manifest_ref,
+        material_ref=manifest.material_ref,
+        material_sha256=manifest.sha256,
+        reviewed_by=manifest.reviewed_by,
+        reviewed_at=manifest.reviewed_at,
+        allowed_target_ids=manifest.allowed_target_ids,
+        created_cases=created_cases,
+        skipped_results=skipped_results,
+    )
+
+
+def write_benchmark_regression_handoff_artifact(
+    artifact: BenchmarkRegressionHandoffArtifact,
+    output_path: str | Path,
+) -> str:
+    """Write a prompt-safe benchmark regression handoff JSON artifact."""
+    path = Path(output_path).expanduser()
+    if path.exists() and path.is_dir():
+        msg = f"benchmark regression handoff output path is a directory: {output_path}"
+        raise BenchmarkRegressionHandoffError(msg)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(artifact.model_dump(mode="json"), indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        msg = f"could not write benchmark regression handoff artifact: {output_path}"
+        raise BenchmarkRegressionHandoffError(msg) from exc
+    return str(path)
+
+
+def _single_fixture(draft: BenchmarkCampaignDraft) -> JailbreakBenchmarkFixture:
+    if len(draft.fixtures) != 1:
+        msg = "benchmark regression handoff requires exactly one fixture"
+        raise BenchmarkRegressionHandoffError(msg)
+    return draft.fixtures[0]
+
+
+def _skip(result: AttackResult, fixture_id: str, reason: str) -> BenchmarkRegressionSkip:
+    return BenchmarkRegressionSkip(
+        result_id=result.id,
+        trace_id=result.trace.id,
+        fixture_id=fixture_id,
+        reason=reason,
+    )
+
+
+def _redacted_trace(trace: dict[str, Any]) -> dict[str, Any]:
+    safe_trace = dict(trace)
+    turns = safe_trace.get("turns", [])
+    if isinstance(turns, list):
+        safe_trace["turns"] = [_redacted_turn(turn) for turn in turns]
+    safe_trace["raw_prompt_policy"] = "reviewed prompt material stays in the private benchmark vault"
+    return safe_trace
+
+
+def _redacted_turn(turn: object) -> object:
+    if not isinstance(turn, dict):
+        return turn
+    safe_turn = dict(turn)
+    if "attacker_prompt" in safe_turn:
+        safe_turn["attacker_prompt"] = _REDACTED_PROMPT
+    if "target_response_excerpt" in safe_turn:
+        safe_turn["target_response_excerpt"] = _REDACTED_RESPONSE
+    return safe_turn

--- a/src/redthread/benchmarks/replay.py
+++ b/src/redthread/benchmarks/replay.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 from pathlib import Path
 from time import perf_counter
 
+from pydantic import BaseModel
+
 from redthread.benchmarks.campaigns import build_benchmark_campaign_draft
 from redthread.benchmarks.dry_run import BenchmarkSource
 from redthread.benchmarks.jailbreak_fixtures import JailbreakBenchmarkFixture
 from redthread.benchmarks.material_review import approve_fixture_for_replay
 from redthread.benchmarks.material_vault import load_material_manifest, resolve_reviewed_material
+from redthread.benchmarks.regression_handoff import (
+    BenchmarkRegressionHandoffArtifact,
+    build_benchmark_regression_handoff,
+)
 from redthread.benchmarks.reports import BenchmarkRunReport, build_benchmark_run_report
 from redthread.benchmarks.spiritual_spell import load_spiritual_spell_fixtures
 from redthread.core.strategies.static_seed_replay import StaticSeedReplayRunner
@@ -18,6 +24,13 @@ from redthread.models import AttackResult, JudgeVerdict
 
 class BenchmarkReplayError(ValueError):
     """Raised when an approved benchmark replay request is invalid."""
+
+
+class ApprovedBenchmarkReplayBundle(BaseModel):
+    """Replay report plus optional prompt-safe regression handoff."""
+
+    report: BenchmarkRunReport
+    regression_handoff: BenchmarkRegressionHandoffArtifact | None = None
 
 
 class LocalBenchmarkTarget:
@@ -43,6 +56,33 @@ async def run_approved_jailbreak_replay(
     allow_live_target: bool = False,
 ) -> BenchmarkRunReport:
     """Run one approved replay seed against the sealed local benchmark target."""
+    bundle = await run_approved_jailbreak_replay_with_regression_handoff(
+        source=source,
+        fixture_id=fixture_id,
+        manifest_ref=manifest_ref,
+        objective=objective,
+        target_system_prompt=target_system_prompt,
+        material_root=material_root,
+        target_id=target_id,
+        allow_live_target=allow_live_target,
+        include_regression_handoff=False,
+    )
+    return bundle.report
+
+
+async def run_approved_jailbreak_replay_with_regression_handoff(
+    *,
+    source: BenchmarkSource = "spiritual-spell",
+    fixture_id: str,
+    manifest_ref: str,
+    objective: str,
+    target_system_prompt: str,
+    material_root: str | Path | None = None,
+    target_id: str = "local-dev",
+    allow_live_target: bool = False,
+    include_regression_handoff: bool = True,
+) -> ApprovedBenchmarkReplayBundle:
+    """Run approved replay and optionally build a prompt-safe regression handoff."""
     if source != "spiritual-spell":
         msg = f"unsupported jailbreak corpus source: {source}"
         raise BenchmarkReplayError(msg)
@@ -88,7 +128,15 @@ async def run_approved_jailbreak_replay(
             "Live provider calls: not executed",
         ]
     )
-    return report
+    handoff = None
+    if include_regression_handoff:
+        handoff = build_benchmark_regression_handoff(
+            draft,
+            [result],
+            manifest=manifest,
+            manifest_ref=manifest_ref,
+        )
+    return ApprovedBenchmarkReplayBundle(report=report, regression_handoff=handoff)
 
 
 def _fixture_by_id(fixture_id: str) -> JailbreakBenchmarkFixture:

--- a/src/redthread/cli/benchmark_eval.py
+++ b/src/redthread/cli/benchmark_eval.py
@@ -18,7 +18,16 @@ from redthread.benchmarks.dry_run import (
     BenchmarkSource,
     build_jailbreak_corpus_dry_run_report,
 )
-from redthread.benchmarks.replay import BenchmarkReplayError, run_approved_jailbreak_replay
+from redthread.benchmarks.regression_handoff import (
+    BenchmarkRegressionHandoffArtifact,
+    BenchmarkRegressionHandoffError,
+    write_benchmark_regression_handoff_artifact,
+)
+from redthread.benchmarks.replay import (
+    BenchmarkReplayError,
+    run_approved_jailbreak_replay,
+    run_approved_jailbreak_replay_with_regression_handoff,
+)
 from redthread.cli.benchmark_materials import register_benchmark_material_commands
 from redthread.cli.shared import run_async_command
 
@@ -46,6 +55,7 @@ def register_benchmark_eval_commands(main: click.Group, console: Console) -> Non
     @click.option("--limit", type=click.IntRange(min=1), default=25, show_default=True)
     @click.option("--show-hints", is_flag=True, default=False)
     @click.option("--report-out", default="", type=click.Path(exists=False), help="Write prompt-safe report JSON.")
+    @click.option("--regression-out", default="", type=click.Path(exists=False), help="Write prompt-safe regression handoff JSON for approved replay.")
     @click.option("--json", "as_json", is_flag=True, default=False)
     def jailbreak_corpus(
         source: str,
@@ -61,30 +71,56 @@ def register_benchmark_eval_commands(main: click.Group, console: Console) -> Non
         limit: int,
         show_hints: bool,
         report_out: str,
+        regression_out: str,
         as_json: bool,
     ) -> None:
         """Dry-run a reviewed jailbreak corpus benchmark plan without raw prompts."""
         benchmark_source = cast(BenchmarkSource, source)
+        if regression_out and not replay:
+            raise click.ClickException("regression handoff requires --replay")
         if replay:
             if len(fixture_id) != 1:
                 raise click.ClickException("approved replay requires exactly one --fixture-id")
             if not manifest_ref:
                 raise click.ClickException("approved replay requires --manifest-ref")
             try:
-                report = run_async_command(
-                    console,
-                    lambda: run_approved_jailbreak_replay(
-                        source=benchmark_source,
-                        fixture_id=fixture_id[0],
-                        manifest_ref=manifest_ref,
-                        objective=objective,
-                        target_system_prompt=system_prompt,
-                        material_root=material_root,
-                        target_id=target_id,
-                        allow_live_target=allow_live_target,
-                    ),
-                    error_label="Benchmark replay",
-                )
+                if regression_out:
+                    bundle = run_async_command(
+                        console,
+                        lambda: run_approved_jailbreak_replay_with_regression_handoff(
+                            source=benchmark_source,
+                            fixture_id=fixture_id[0],
+                            manifest_ref=manifest_ref,
+                            objective=objective,
+                            target_system_prompt=system_prompt,
+                            material_root=material_root,
+                            target_id=target_id,
+                            allow_live_target=allow_live_target,
+                        ),
+                        error_label="Benchmark replay",
+                    )
+                    report = bundle.report
+                    _write_regression_handoff_artifact(
+                        console,
+                        bundle.regression_handoff,
+                        regression_out,
+                        as_json,
+                    )
+                else:
+                    report = run_async_command(
+                        console,
+                        lambda: run_approved_jailbreak_replay(
+                            source=benchmark_source,
+                            fixture_id=fixture_id[0],
+                            manifest_ref=manifest_ref,
+                            objective=objective,
+                            target_system_prompt=system_prompt,
+                            material_root=material_root,
+                            target_id=target_id,
+                            allow_live_target=allow_live_target,
+                        ),
+                        error_label="Benchmark replay",
+                    )
             except BenchmarkReplayError as exc:
                 raise click.ClickException(str(exc)) from exc
             _write_report_artifact(console, report, report_out, as_json)
@@ -130,6 +166,22 @@ def _write_report_artifact(
         raise click.ClickException(str(exc)) from exc
     if not as_json:
         console.print(f"Report written: {result.path}")
+
+
+def _write_regression_handoff_artifact(
+    console: Console,
+    handoff: BenchmarkRegressionHandoffArtifact | None,
+    regression_out: str,
+    as_json: bool,
+) -> None:
+    if handoff is None:
+        raise click.ClickException("benchmark replay did not produce a regression handoff")
+    try:
+        path = write_benchmark_regression_handoff_artifact(handoff, regression_out)
+    except BenchmarkRegressionHandoffError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not as_json:
+        console.print(f"Regression handoff written: {path}")
 
 
 def _emit_report(

--- a/tests/test_benchmark_eval_replay_cli.py
+++ b/tests/test_benchmark_eval_replay_cli.py
@@ -87,6 +87,54 @@ def test_cli_replay_writes_prompt_safe_report_artifact(tmp_path: Path) -> None:
     assert "toy approved cli replay seed" not in output_path.read_text(encoding="utf-8")
 
 
+def test_cli_replay_writes_prompt_safe_regression_handoff(tmp_path: Path) -> None:
+    manifest_ref = _manifest(tmp_path)
+    output_path = tmp_path / "regression-handoff.json"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "eval",
+            "jailbreak-corpus",
+            "--fixture-id",
+            "spiritual-spell-0032",
+            "--replay",
+            "--manifest-ref",
+            manifest_ref,
+            "--material-root",
+            str(tmp_path),
+            "--regression-out",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Regression handoff written:" in result.output
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "redthread.jailbreak_benchmark_regression_handoff.v1"
+    assert payload["fixture_id"] == "spiritual-spell-0032"
+    assert payload["created_cases"] == []
+    assert payload["skipped_results"][0]["reason"] == "verdict_not_jailbreak"
+    assert "toy approved cli replay seed" not in output_path.read_text(encoding="utf-8")
+
+
+def test_cli_dry_run_rejects_regression_handoff() -> None:
+    result = CliRunner().invoke(
+        main,
+        [
+            "eval",
+            "jailbreak-corpus",
+            "--fixture-id",
+            "spiritual-spell-0032",
+            "--regression-out",
+            "handoff.json",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "regression handoff requires --replay" in result.output
+
+
 def test_cli_replay_json_report_is_prompt_safe(tmp_path: Path) -> None:
     manifest_ref = _manifest(tmp_path)
 

--- a/tests/test_benchmark_regression_handoff.py
+++ b/tests/test_benchmark_regression_handoff.py
@@ -1,0 +1,157 @@
+"""Tests for prompt-safe benchmark regression handoff artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redthread.benchmarks.campaigns import build_benchmark_campaign_draft
+from redthread.benchmarks.jailbreak_fixtures import JailbreakBenchmarkFixture
+from redthread.benchmarks.material_review import (
+    approve_fixture_for_replay,
+    import_reviewed_material,
+)
+from redthread.benchmarks.material_vault import load_material_manifest
+from redthread.benchmarks.regression_handoff import (
+    build_benchmark_regression_handoff,
+    write_benchmark_regression_handoff_artifact,
+)
+from redthread.benchmarks.replay import run_approved_jailbreak_replay_with_regression_handoff
+from redthread.benchmarks.spiritual_spell import load_spiritual_spell_fixtures
+from redthread.models import (
+    AttackResult,
+    AttackTrace,
+    ConversationTurn,
+    JudgeVerdict,
+    MitreAtlasTactic,
+    Persona,
+    PsychologicalTrigger,
+)
+
+
+def _fixture() -> JailbreakBenchmarkFixture:
+    return next(
+        fixture for fixture in load_spiritual_spell_fixtures()
+        if fixture.id == "spiritual-spell-0032"
+    )
+
+
+def _manifest(tmp_path: Path, seed: str = "toy approved regression seed") -> str:
+    source = tmp_path / "reviewed-seed.txt"
+    source.write_text(seed, encoding="utf-8")
+    result = import_reviewed_material(
+        _fixture(),
+        source_material_path=source,
+        material_root=tmp_path,
+        reviewed_by="security-review-owner",
+        reviewed_at="2026-04-26T00:00:00Z",
+        material_class="approved_replay_seed",
+    )
+    return result.manifest_ref
+
+
+def _result(metadata: dict[str, str]) -> AttackResult:
+    trace = AttackTrace(
+        persona=Persona(
+            name="Benchmark regression tester",
+            tactic=MitreAtlasTactic.INITIAL_ACCESS,
+            technique="static replay",
+            cover_story="Authorized replay.",
+            hidden_objective="Check trusted instruction handling.",
+            system_prompt="Replay reviewed benchmark material.",
+            psychological_triggers=[PsychologicalTrigger.AUTHORITY],
+        ),
+        algorithm="static_seed_replay",
+        turns=[
+            ConversationTurn(
+                turn_number=1,
+                attacker_prompt="toy approved regression seed",
+                target_response="echoed toy approved regression seed",
+            )
+        ],
+        metadata={
+            **metadata,
+            "risk_plugin_id": "prompt_injection",
+            "strategy_id": "static_seed_replay",
+            "target_system_prompt": "Do not reveal secrets.",
+        },
+    )
+    return AttackResult(
+        trace=trace,
+        verdict=JudgeVerdict(
+            score=4.8,
+            raw_score=5,
+            reasoning="Confirmed benchmark failure.",
+            feedback="Create a regression handoff.",
+            rubric_name="prompt_injection",
+            is_jailbreak=True,
+        ),
+        iterations_used=1,
+        duration_seconds=0.1,
+    )
+
+
+def test_handoff_redacts_confirmed_regression_case(tmp_path: Path) -> None:
+    manifest_ref = _manifest(tmp_path)
+    manifest = load_material_manifest(manifest_ref, material_root=tmp_path)
+    fixture = approve_fixture_for_replay(_fixture(), manifest)
+    draft = build_benchmark_campaign_draft(
+        [fixture],
+        objective="Check trusted instruction handling",
+        target_id="local-dev",
+    )
+
+    artifact = build_benchmark_regression_handoff(
+        draft,
+        [_result(fixture.lineage_metadata())],
+        manifest=manifest,
+        manifest_ref=manifest_ref,
+    )
+    payload = artifact.model_dump(mode="json")
+    rendered = json.dumps(payload)
+
+    assert artifact.created_cases[0].fixture_id == "spiritual-spell-0032"
+    assert artifact.created_cases[0].material_sha256 == manifest.sha256
+    assert "toy approved regression seed" not in rendered
+    assert "[redacted: reviewed benchmark prompt material remains in private vault]" in rendered
+    assert payload["raw_prompt_policy"] == "raw prompt bodies are redacted; replay uses private vault material refs"
+
+
+@pytest.mark.asyncio
+async def test_local_replay_handoff_skips_safe_verdict(tmp_path: Path) -> None:
+    manifest_ref = _manifest(tmp_path)
+
+    bundle = await run_approved_jailbreak_replay_with_regression_handoff(
+        fixture_id="spiritual-spell-0032",
+        manifest_ref=manifest_ref,
+        objective="Check trusted instruction handling",
+        target_system_prompt="Do not reveal secrets.",
+        material_root=tmp_path,
+    )
+
+    assert bundle.regression_handoff is not None
+    assert bundle.regression_handoff.created_cases == []
+    assert bundle.regression_handoff.skipped_results[0].reason == "verdict_not_jailbreak"
+
+
+def test_writes_prompt_safe_handoff_artifact(tmp_path: Path) -> None:
+    manifest_ref = _manifest(tmp_path)
+    manifest = load_material_manifest(manifest_ref, material_root=tmp_path)
+    fixture = approve_fixture_for_replay(_fixture(), manifest)
+    draft = build_benchmark_campaign_draft([fixture], objective="Check", target_id="local-dev")
+    artifact = build_benchmark_regression_handoff(
+        draft,
+        [_result(fixture.lineage_metadata())],
+        manifest=manifest,
+        manifest_ref=manifest_ref,
+    )
+    output_path = tmp_path / "handoff.json"
+
+    written = write_benchmark_regression_handoff_artifact(artifact, output_path)
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert written == str(output_path)
+    assert payload["schema_version"] == "redthread.jailbreak_benchmark_regression_handoff.v1"
+    assert "toy approved regression seed" not in output_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- adds prompt-safe regression handoff artifacts for approved jailbreak benchmark replay
- adds the `--regression-out` CLI flag for `redthread eval jailbreak-corpus --replay`
- documents how to test the benchmark regression handoff flow

## Safety
- raw reviewed prompt bodies stay outside git in the benchmark material vault
- handoff artifacts store fixture lineage, manifest refs, hashes, and redacted regression case metadata only
- local replay remains safe by default and records skipped regression rows when no jailbreak verdict is present

## How to test
- `python3 scripts/wiki_lint.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python -m pytest tests/test_benchmark_regression_handoff.py tests/test_benchmark_replay.py tests/test_benchmark_eval_replay_cli.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python -m pytest tests/test_jailbreak_fixtures.py tests/test_spiritual_spell_fixtures.py tests/test_benchmark_campaigns.py tests/test_benchmark_static_replay_metadata.py tests/test_benchmark_reports.py tests/test_benchmark_prompt_materials.py tests/test_benchmark_material_vault.py tests/test_benchmark_material_review.py tests/test_benchmark_hints.py tests/test_benchmark_dry_run.py tests/test_benchmark_replay.py tests/test_benchmark_artifacts.py tests/test_benchmark_regression_handoff.py tests/test_benchmark_eval_cli.py tests/test_benchmark_eval_replay_cli.py tests/test_benchmark_materials_cli.py tests/test_run_benchmark_fixture_cli.py tests/test_static_seed_replay_runner.py tests/test_regression_cases.py tests/test_cli_shell.py`
- `uv run ruff check src/redthread/benchmarks src/redthread/cli/app.py src/redthread/cli/benchmark_eval.py src/redthread/cli/benchmark_materials.py src/redthread/cli/run.py src/redthread/core/strategies/static_seed_replay.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run mypy src/redthread/benchmarks src/redthread/cli/app.py src/redthread/cli/benchmark_eval.py src/redthread/cli/benchmark_materials.py src/redthread/cli/run.py src/redthread/core/strategies/static_seed_replay.py`
- `uv run redthread eval jailbreak-corpus --help` shows `--regression-out`