### PR TITLE
Add live canary containment gates

### DIFF
--- a/docs/AGENTIC_SECURITY_RUNTIME.md
+++ b/docs/AGENTIC_SECURITY_RUNTIME.md
@@ -138,8 +138,18 @@ In `src/redthread/tools/sandbox_tool.py`, `SandboxTool` can do the same before r
 In `src/redthread/core/defense_replay_runner.py`, live defense replay now authorizes each replay case before the patched target send and records that decision on the replay case evidence itself.
 If authorization is not `allow`, the target send is blocked before execution.
 
-This is still not the same as broad production enforcement.
-It is a narrow proof-of-control hook.
+Live canary containment now has a central guard on the shared provider-send helper.
+`send_with_execution_metadata()` and `send_with_usage_and_execution_metadata()` evaluate canary tags before target execution.
+Analysis-only seams such as `judge.score` may carry canary-tagged evidence.
+Protected execution seams such as `tool.attack`, `sandbox.replay`, `defense.replay`, `strategy.static_seed_replay`, and target lanes block canary-tagged content before the provider call runs.
+Direct production sends in `AttackTool`, `SandboxTool`, `ControlledLiveAdapter`, and static seed replay now route through the shared helper with seam metadata.
+Runtime summaries can merge live canary decisions under `runtime_summary.agentic_security.live_canary_report`.
+Destructive `RedThreadTool.run()` calls now evaluate `ToolContext.canary_tags` before tool execution.
+`MemoryIndex.append()` blocks canary-tagged guardrail or replay content before writing `MEMORY.md` or `deployments.jsonl`.
+The replay promotion gate now fails any trace whose sealed or live canary report reaches an execution boundary without containment.
+
+This is still not universal enterprise enforcement.
+It is the first broad shared-send containment layer and depends on production paths using the shared metadata helper.
 
 ---
 

--- a/docs/PHASE8_TESTING_GUIDE.md
+++ b/docs/PHASE8_TESTING_GUIDE.md
@@ -44,6 +44,7 @@ Do the runtime smoke second.
 
 ### Phase 8D — Canary and runtime containment
 - canary propagation report
+- live canary containment guard on shared send helpers
 - runtime budget checks
 - runtime summary extension
 
@@ -67,9 +68,11 @@ Do the runtime smoke second.
 - `src/redthread/orchestration/models/agentic_security.py`
 - `src/redthread/orchestration/permission_inheritance.py`
 - `src/redthread/orchestration/canary_flow.py`
+- `src/redthread/orchestration/canary_containment.py`
 - `src/redthread/orchestration/scenarios/confused_deputy.py`
 - `src/redthread/orchestration/scenarios/resource_amplification.py`
 - `src/redthread/orchestration/graphs/tool_attack_graph.py`
+- `src/redthread/tools/base.py`
 - `src/redthread/tools/authorization/engine.py`
 - `src/redthread/tools/authorization/models.py`
 - `src/redthread/tools/authorization/presets.py`
@@ -79,6 +82,8 @@ Do the runtime smoke second.
 - `src/redthread/telemetry/runtime_budgets.py`
 - `src/redthread/evaluation/replay_corpus.py`
 - `src/redthread/evaluation/promotion_gate.py`
+- `src/redthread/memory/index.py`
+- `src/redthread/pyrit_adapters/send_helpers.py`
 - `src/redthread/pyrit_adapters/controlled.py`
 - `src/redthread/engine.py`
 
@@ -88,6 +93,7 @@ Do the runtime smoke second.
 - `tests/test_authorization_engine.py`
 - `tests/test_canary_containment.py`
 - `tests/test_agentic_replay_promotion.py`
+- `tests/test_defense_memory.py`
 - `tests/test_supervisor.py`
 - `tests/test_runtime_truth.py`
 

--- a/docs/PHASE_REGISTRY.md
+++ b/docs/PHASE_REGISTRY.md
@@ -434,6 +434,7 @@ TERMINAL EVALUATION
 **Deliverables**:
 - `src/redthread/telemetry/canaries.py` — canary injection and merge helpers
 - `src/redthread/orchestration/canary_flow.py` — stage-by-stage propagation reports
+- `src/redthread/orchestration/canary_containment.py` — live canary boundary classifier and containment guard
 - `src/redthread/telemetry/runtime_budgets.py` — deterministic runtime budget evaluator
 - `src/redthread/orchestration/runtime_summary.py` — additive canary and budget reporting fields
 - `tests/test_canary_containment.py` — canary flow and budget stop coverage
@@ -444,7 +445,7 @@ TERMINAL EVALUATION
 | Canary reporting | stage list to compact report | Makes spread-path evidence inspectable without overcomplicating runtime state |
 | Budget control | deterministic threshold gate | Keeps amplification containment replay-safe and CI-friendly |
 | Summary impact | additive nested fields | Preserves existing operator truth surfaces while exposing new containment signals |
-| Scope control | sealed reporting only in v1 | Live hook wiring remains deferred to the next phase |
+| Scope control | shared-send live containment after v1 | Canary-tagged content is blocked at protected execution and memory boundaries while analysis-only seams can inspect evidence |
 
 ### Phase 8E: Replay, Promotion, and Controlled Live Adapters ✅
 **Objective**: Add replay-bundle gating and a fail-closed live adapter wrapper so agentic-security controls must pass sealed promotion checks before any live traffic path can open.
@@ -453,8 +454,10 @@ TERMINAL EVALUATION
 
 **Deliverables**:
 - `src/redthread/evaluation/replay_corpus.py` — replay trace and bundle models
-- `src/redthread/evaluation/promotion_gate.py` — deterministic replay promotion evaluator
+- `src/redthread/evaluation/promotion_gate.py` — deterministic replay promotion evaluator with uncontained-canary failure checks
 - `src/redthread/pyrit_adapters/controlled.py` — fail-closed controlled live adapter wrapper
+- `src/redthread/pyrit_adapters/send_helpers.py` — shared live send path with canary containment decisions
+- `src/redthread/tools/base.py` and `src/redthread/memory/index.py` — tool and memory-write containment gates
 - `tests/test_agentic_replay_promotion.py` — replay pass/fail and live-adapter lock coverage
 
 **Key Decisions**:

--- a/src/redthread/config/settings.py
+++ b/src/redthread/config/settings.py
@@ -22,6 +22,13 @@ class TargetBackend(str, Enum):
     LLAMA_CPP = "llama_cpp"
 
 
+class CanaryPolicyPreset(str, Enum):
+    MONITOR_ONLY = "monitor_only"
+    BLOCK_EXECUTION_BOUNDARY = "block_execution_boundary"
+    BLOCK_MEMORY_AND_OUTBOUND = "block_memory_and_outbound"
+    STRICT_FAIL_CLOSED = "strict_fail_closed"
+
+
 class ModelRole(str, Enum):
     """Asymmetric deployment roles."""
     ATTACKER = "attacker"           # Lightweight: fast, fewer safety filters
@@ -213,6 +220,10 @@ class RedThreadSettings(BaseSettings):
     dry_run: bool = Field(
         default=False,
         description="Validate config + generate persona but do not send to target",
+    )
+    canary_policy_preset: CanaryPolicyPreset = Field(
+        default=CanaryPolicyPreset.BLOCK_MEMORY_AND_OUTBOUND,
+        description="Live canary containment mode for execution, memory, and outbound seams",
     )
 
     # ── Telemetry / ASI (Phase 5B) ────────────────────────────────────────────

--- a/src/redthread/core/strategies/static_seed_replay.py
+++ b/src/redthread/core/strategies/static_seed_replay.py
@@ -20,6 +20,7 @@ from redthread.models import (
     PsychologicalTrigger,
 )
 from redthread.orchestration.models import AttackStrategySpec, CampaignPlan, PlannedRisk
+from redthread.pyrit_adapters.targets import ExecutionMetadata, send_with_execution_metadata
 
 
 class StaticSeedReplayRunner:
@@ -58,9 +59,16 @@ class StaticSeedReplayRunner:
             ),
         )
         for index, prompt in enumerate(prompts, start=1):
-            response = await target.send(
-                prompt,
+            response = await send_with_execution_metadata(
+                target,
+                prompt=prompt,
                 conversation_id=f"{self.strategy_id}-{trace.id}-t{index}",
+                execution_metadata=ExecutionMetadata(
+                    seam="strategy.static_seed_replay",
+                    role="attack_worker",
+                    evidence_class="live_attack",
+                    metadata={"trace_id": trace.id, "turn": index},
+                ),
             )
             trace.turns.append(
                 ConversationTurn(

--- a/src/redthread/engine.py
+++ b/src/redthread/engine.py
@@ -75,3 +75,11 @@ class RedThreadEngine:
         summary = build_execution_truth_summary(execution_records)
         campaign.metadata["execution_truth_summary"] = summary
         campaign.metadata["execution_records_sample"] = summary["record_sample"]
+        runtime_summary = campaign.metadata.get("runtime_summary")
+        if isinstance(runtime_summary, dict):
+            from redthread.orchestration.runtime_summary import merge_live_canary_report
+
+            campaign.metadata["runtime_summary"] = merge_live_canary_report(
+                runtime_summary,
+                execution_records,
+            )

--- a/src/redthread/evaluation/promotion_gate.py
+++ b/src/redthread/evaluation/promotion_gate.py
@@ -19,9 +19,17 @@ def evaluate_agentic_promotion(bundle: ReplayBundle) -> PromotionGateResult:
                 failures.append(f"{trace.trace_id}:authorization:{actual}")
 
         if trace.expect_canary_contained is not None:
-            contained = bool(trace.canary_report.get("contained"))
+            canary_report = trace.live_canary_report or trace.canary_report
+            contained = bool(canary_report.get("contained"))
             if contained != trace.expect_canary_contained:
                 failures.append(f"{trace.trace_id}:canary:{contained}")
+
+        for report_name, report in (
+            ("canary", trace.canary_report),
+            ("live_canary", trace.live_canary_report),
+        ):
+            if report.get("reached_execution_boundary") and not report.get("contained"):
+                failures.append(f"{trace.trace_id}:{report_name}:uncontained_execution_boundary")
 
         if trace.expect_budget_stop is not None:
             stop = bool(trace.budget_decision.get("stop_triggered"))

--- a/src/redthread/evaluation/replay_corpus.py
+++ b/src/redthread/evaluation/replay_corpus.py
@@ -11,6 +11,7 @@ class ReplayTrace(BaseModel):
     scenario_result: dict[str, object] = Field(default_factory=dict)
     authorization_decision: dict[str, object] | None = None
     canary_report: dict[str, object] = Field(default_factory=dict)
+    live_canary_report: dict[str, object] = Field(default_factory=dict)
     budget_decision: dict[str, object] = Field(default_factory=dict)
     expected_authorization: str | None = None
     expect_canary_contained: bool | None = None

--- a/src/redthread/memory/index.py
+++ b/src/redthread/memory/index.py
@@ -49,6 +49,7 @@ class MemoryIndex:
     """Access append-only markdown and JSONL deployment records."""
 
     def __init__(self, settings: RedThreadSettings) -> None:
+        self._settings = settings
         self._path: Path = settings.memory_dir / _MEMORY_FILENAME
         self._deployments_path: Path = settings.memory_dir / _DEPLOYMENTS_FILENAME
         self._ensure_files()
@@ -59,6 +60,7 @@ class MemoryIndex:
             seam="memory.write",
             prompt=f"{record.guardrail_clause}\n{record.validation.replay_response}",
             metadata=record.metadata,
+            mode=self._settings_canary_policy(),
         )
         if canary_decision.blocked:
             logger.warning(
@@ -76,6 +78,9 @@ class MemoryIndex:
             handle.write(json.dumps(asdict(record)) + "\n")
         logger.info("📚 MemoryIndex updated | trace=%s | category=%s", record.trace_id, record.classification.category)
         return True
+
+    def _settings_canary_policy(self) -> str:
+        return self._settings.canary_policy_preset.value
 
     def append_records(self, records: Iterable[DeploymentRecord]) -> list[str]:
         """Append a bounded batch and return the trace IDs written this time."""

--- a/src/redthread/memory/index.py
+++ b/src/redthread/memory/index.py
@@ -17,6 +17,7 @@ from redthread.core.defense_synthesis import (
     ValidationResult,
     VulnerabilityClassification,
 )
+from redthread.orchestration.canary_containment import evaluate_canary_containment
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,18 @@ class MemoryIndex:
 
     def append(self, record: DeploymentRecord) -> bool:
         """Append a deployment record unless its trace ID already exists."""
+        canary_decision = evaluate_canary_containment(
+            seam="memory.write",
+            prompt=f"{record.guardrail_clause}\n{record.validation.replay_response}",
+            metadata=record.metadata,
+        )
+        if canary_decision.blocked:
+            logger.warning(
+                "MemoryIndex blocked canary-tagged write | trace=%s | tags=%s",
+                record.trace_id,
+                canary_decision.canary_tags,
+            )
+            return False
         if self._is_duplicate(record.trace_id):
             logger.debug("MemoryIndex: duplicate trace_id=%s — skipping.", record.trace_id)
             return False

--- a/src/redthread/orchestration/canary_containment.py
+++ b/src/redthread/orchestration/canary_containment.py
@@ -30,6 +30,13 @@ class CanaryContainmentDecisionType(str, Enum):
     ESCALATE = "escalate"
 
 
+class CanaryPolicyPreset(str, Enum):
+    MONITOR_ONLY = "monitor_only"
+    BLOCK_EXECUTION_BOUNDARY = "block_execution_boundary"
+    BLOCK_MEMORY_AND_OUTBOUND = "block_memory_and_outbound"
+    STRICT_FAIL_CLOSED = "strict_fail_closed"
+
+
 class CanaryBoundaryKind(str, Enum):
     ANALYSIS_ONLY = "analysis_only"
     SHARED_STATE = "shared_state"
@@ -97,7 +104,7 @@ def evaluate_canary_containment(
     prompt: str = "",
     metadata: dict[str, Any] | None = None,
     canary_tags: list[str] | None = None,
-    mode: str = "block_execution_boundary",
+    mode: str | CanaryPolicyPreset = CanaryPolicyPreset.BLOCK_MEMORY_AND_OUTBOUND,
 ) -> CanaryContainmentDecision:
     """Return the live containment decision for one pending boundary crossing."""
     tags = extract_canary_tags(prompt, metadata, canary_tags or [])
@@ -117,7 +124,8 @@ def evaluate_canary_containment(
             canary_tags=tags,
             reason="analysis-only boundary allows tagged evidence",
         )
-    if mode in {"monitor_only", "off"}:
+    policy = CanaryPolicyPreset(mode) if mode != "off" else CanaryPolicyPreset.MONITOR_ONLY
+    if policy == CanaryPolicyPreset.MONITOR_ONLY:
         return CanaryContainmentDecision(
             decision=CanaryContainmentDecisionType.ALLOW,
             seam=seam,
@@ -125,7 +133,19 @@ def evaluate_canary_containment(
             canary_tags=tags,
             reason="monitor-only canary policy",
         )
-    if boundary in {CanaryBoundaryKind.EXECUTION_BOUNDARY, CanaryBoundaryKind.MEMORY_WRITE}:
+    if policy == CanaryPolicyPreset.STRICT_FAIL_CLOSED:
+        return CanaryContainmentDecision(
+            decision=CanaryContainmentDecisionType.BLOCK,
+            seam=seam,
+            boundary=boundary,
+            canary_tags=tags,
+            blocked_point=seam,
+            reason="strict canary policy blocks tagged boundary crossing",
+        )
+    protected = {CanaryBoundaryKind.EXECUTION_BOUNDARY}
+    if policy == CanaryPolicyPreset.BLOCK_MEMORY_AND_OUTBOUND:
+        protected.add(CanaryBoundaryKind.MEMORY_WRITE)
+    if boundary in protected:
         return CanaryContainmentDecision(
             decision=CanaryContainmentDecisionType.BLOCK,
             seam=seam,

--- a/src/redthread/orchestration/canary_containment.py
+++ b/src/redthread/orchestration/canary_containment.py
@@ -1,0 +1,143 @@
+"""Live canary containment guard for production execution boundaries."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+_CANARY_RE = re.compile(r"\bCANARY_[A-Z0-9_]+\b")
+_EXECUTION_BOUNDARY_SEAMS = {
+    "attack.target",
+    "controlled.live_adapter",
+    "defense.replay",
+    "sandbox.replay",
+    "strategy.static_seed_replay",
+    "telemetry.canary",
+    "tool.attack",
+}
+_ANALYSIS_ONLY_SEAMS = {
+    "judge.autocot",
+    "judge.score",
+}
+
+
+class CanaryContainmentDecisionType(str, Enum):
+    ALLOW = "allow"
+    BLOCK = "block"
+    ESCALATE = "escalate"
+
+
+class CanaryBoundaryKind(str, Enum):
+    ANALYSIS_ONLY = "analysis_only"
+    SHARED_STATE = "shared_state"
+    MEMORY_WRITE = "memory_write"
+    EXECUTION_BOUNDARY = "execution_boundary"
+    UNKNOWN = "unknown"
+
+
+class CanaryContainmentDecision(BaseModel):
+    decision: CanaryContainmentDecisionType
+    seam: str
+    boundary: CanaryBoundaryKind
+    canary_tags: list[str] = Field(default_factory=list)
+    blocked_point: str | None = None
+    reason: str
+
+    @property
+    def blocked(self) -> bool:
+        return self.decision == CanaryContainmentDecisionType.BLOCK
+
+
+def extract_canary_tags(*values: Any) -> list[str]:
+    """Extract stable canary tags from strings, lists, and nested metadata."""
+    tags: list[str] = []
+
+    def add(tag: str) -> None:
+        if tag.startswith("CANARY_") and tag not in tags:
+            tags.append(tag)
+
+    def walk(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, str):
+            for match in _CANARY_RE.findall(value):
+                add(match)
+            return
+        if isinstance(value, dict):
+            for item in value.values():
+                walk(item)
+            return
+        if isinstance(value, (list, tuple, set)):
+            for item in value:
+                walk(item)
+
+    for value in values:
+        walk(value)
+    return tags
+
+
+def classify_canary_boundary(seam: str) -> CanaryBoundaryKind:
+    if seam in _ANALYSIS_ONLY_SEAMS or seam.startswith("judge."):
+        return CanaryBoundaryKind.ANALYSIS_ONLY
+    if seam in _EXECUTION_BOUNDARY_SEAMS or seam.endswith(".target") or seam.startswith("tool."):
+        return CanaryBoundaryKind.EXECUTION_BOUNDARY
+    if "memory" in seam:
+        return CanaryBoundaryKind.MEMORY_WRITE
+    if "state" in seam or "summary" in seam:
+        return CanaryBoundaryKind.SHARED_STATE
+    return CanaryBoundaryKind.UNKNOWN
+
+
+def evaluate_canary_containment(
+    *,
+    seam: str,
+    prompt: str = "",
+    metadata: dict[str, Any] | None = None,
+    canary_tags: list[str] | None = None,
+    mode: str = "block_execution_boundary",
+) -> CanaryContainmentDecision:
+    """Return the live containment decision for one pending boundary crossing."""
+    tags = extract_canary_tags(prompt, metadata, canary_tags or [])
+    boundary = classify_canary_boundary(seam)
+    if not tags:
+        return CanaryContainmentDecision(
+            decision=CanaryContainmentDecisionType.ALLOW,
+            seam=seam,
+            boundary=boundary,
+            reason="no canary tags present",
+        )
+    if boundary == CanaryBoundaryKind.ANALYSIS_ONLY:
+        return CanaryContainmentDecision(
+            decision=CanaryContainmentDecisionType.ALLOW,
+            seam=seam,
+            boundary=boundary,
+            canary_tags=tags,
+            reason="analysis-only boundary allows tagged evidence",
+        )
+    if mode in {"monitor_only", "off"}:
+        return CanaryContainmentDecision(
+            decision=CanaryContainmentDecisionType.ALLOW,
+            seam=seam,
+            boundary=boundary,
+            canary_tags=tags,
+            reason="monitor-only canary policy",
+        )
+    if boundary in {CanaryBoundaryKind.EXECUTION_BOUNDARY, CanaryBoundaryKind.MEMORY_WRITE}:
+        return CanaryContainmentDecision(
+            decision=CanaryContainmentDecisionType.BLOCK,
+            seam=seam,
+            boundary=boundary,
+            canary_tags=tags,
+            blocked_point=seam,
+            reason="canary-tagged content reached a protected boundary",
+        )
+    return CanaryContainmentDecision(
+        decision=CanaryContainmentDecisionType.ALLOW,
+        seam=seam,
+        boundary=boundary,
+        canary_tags=tags,
+        reason="non-execution boundary recorded",
+    )

--- a/src/redthread/orchestration/canary_flow.py
+++ b/src/redthread/orchestration/canary_flow.py
@@ -13,10 +13,13 @@ def build_canary_report(stages: list[dict[str, Any]]) -> dict[str, Any]:
     non_empty = [stage for stage in stages if stage.get("canary_tags")]
     crossed = [stage["stage"] for stage in non_empty]
     execution_boundary = any(stage in {"execution_plan", "outbound_request", "tool_execution"} for stage in crossed)
+    blocked = [stage for stage in non_empty if stage.get("blocked")]
+    first_blocked = blocked[0]["stage"] if blocked else None
     return {
         "injection_point": crossed[0] if crossed else None,
         "crossed_boundaries": crossed,
         "stage_count": len(crossed),
+        "first_blocked_point": first_blocked,
         "reached_execution_boundary": execution_boundary,
-        "contained": bool(crossed) and not execution_boundary,
+        "contained": bool(crossed) and (bool(first_blocked) or not execution_boundary),
     }

--- a/src/redthread/orchestration/canary_flow.py
+++ b/src/redthread/orchestration/canary_flow.py
@@ -2,24 +2,53 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
+from pydantic import BaseModel, Field
 
-def record_canary_stage(stage: str, canary_tags: list[str]) -> dict[str, Any]:
-    return {"stage": stage, "canary_tags": canary_tags}
+_EXECUTION_STAGES = {"execution_plan", "outbound_request", "tool_execution"}
+
+
+class CanaryStageEvent(BaseModel):
+    """Typed event for one canary boundary crossing."""
+
+    stage: str
+    canary_tags: list[str] = Field(default_factory=list)
+    blocked: bool = False
+
+
+class CanaryPropagationReport(BaseModel):
+    """Typed summary of canary propagation across runtime boundaries."""
+
+    injection_point: str | None = None
+    crossed_boundaries: list[str] = Field(default_factory=list)
+    stage_count: int = 0
+    first_blocked_point: str | None = None
+    reached_execution_boundary: bool = False
+    contained: bool = False
+
+
+def record_canary_stage(stage: str, canary_tags: list[str], *, blocked: bool = False) -> dict[str, Any]:
+    return CanaryStageEvent(stage=stage, canary_tags=canary_tags, blocked=blocked).model_dump(mode="json")
+
+
+def build_typed_canary_report(stages: Sequence[dict[str, Any] | CanaryStageEvent]) -> CanaryPropagationReport:
+    events = [CanaryStageEvent.model_validate(stage) for stage in stages]
+    non_empty = [event for event in events if event.canary_tags]
+    crossed = [event.stage for event in non_empty]
+    execution_boundary = any(stage in _EXECUTION_STAGES for stage in crossed)
+    blocked = [event for event in non_empty if event.blocked]
+    first_blocked = blocked[0].stage if blocked else None
+    return CanaryPropagationReport(
+        injection_point=crossed[0] if crossed else None,
+        crossed_boundaries=crossed,
+        stage_count=len(crossed),
+        first_blocked_point=first_blocked,
+        reached_execution_boundary=execution_boundary,
+        contained=bool(crossed) and (bool(first_blocked) or not execution_boundary),
+    )
 
 
 def build_canary_report(stages: list[dict[str, Any]]) -> dict[str, Any]:
-    non_empty = [stage for stage in stages if stage.get("canary_tags")]
-    crossed = [stage["stage"] for stage in non_empty]
-    execution_boundary = any(stage in {"execution_plan", "outbound_request", "tool_execution"} for stage in crossed)
-    blocked = [stage for stage in non_empty if stage.get("blocked")]
-    first_blocked = blocked[0]["stage"] if blocked else None
-    return {
-        "injection_point": crossed[0] if crossed else None,
-        "crossed_boundaries": crossed,
-        "stage_count": len(crossed),
-        "first_blocked_point": first_blocked,
-        "reached_execution_boundary": execution_boundary,
-        "contained": bool(crossed) and (bool(first_blocked) or not execution_boundary),
-    }
+    return build_typed_canary_report(stages).model_dump(mode="json")

--- a/src/redthread/orchestration/runtime_summary.py
+++ b/src/redthread/orchestration/runtime_summary.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from redthread.orchestration.canary_flow import CanaryPropagationReport
+
 RuntimeSummary = dict[str, Any]
 
 
@@ -9,12 +11,39 @@ def _build_agentic_security_summary(state: dict[str, Any]) -> dict[str, Any]:
     return {
         "action_total": state.get("agentic_action_total", 0),
         "authorization_decision_counts": state.get("authorization_decision_counts", {}),
-        "canary_event_total": state.get("canary_event_total", 0),
+        "canary_event_total": state.get("canary_event_total", 0) + state.get("live_canary_event_total", 0),
         "canary_report": state.get("canary_report", {}),
+        "live_canary_event_total": state.get("live_canary_event_total", 0),
+        "live_canary_report": state.get("live_canary_report", {}),
         "amplification_metrics": state.get("amplification_metrics", {}),
         "budget_stop_triggered": state.get("budget_stop_triggered", False),
         "untrusted_lineage_action_total": state.get("untrusted_lineage_action_total", 0),
     }
+
+
+def merge_canary_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge worker canary reports into one prompt-safe summary."""
+    typed = [CanaryPropagationReport.model_validate(report) for report in reports if report]
+    if not typed:
+        return {}
+    crossed: list[str] = []
+    for report in typed:
+        for boundary in report.crossed_boundaries:
+            if boundary not in crossed:
+                crossed.append(boundary)
+    first_blocked = next((report.first_blocked_point for report in typed if report.first_blocked_point), None)
+    reached_execution = any(report.reached_execution_boundary for report in typed)
+    contained = any(report.contained for report in typed) and not any(
+        report.reached_execution_boundary and not report.contained for report in typed
+    )
+    return CanaryPropagationReport(
+        injection_point=crossed[0] if crossed else None,
+        crossed_boundaries=crossed,
+        stage_count=len(crossed),
+        first_blocked_point=first_blocked,
+        reached_execution_boundary=reached_execution,
+        contained=contained,
+    ).model_dump(mode="json")
 
 
 def merge_live_canary_report(summary: RuntimeSummary, execution_records: list[Any]) -> RuntimeSummary:
@@ -33,14 +62,14 @@ def merge_live_canary_report(summary: RuntimeSummary, execution_records: list[An
         seam = decision.get("seam")
         if seam and seam not in crossed:
             crossed.append(seam)
-    live_report = {
-        "injection_point": crossed[0] if crossed else None,
-        "crossed_boundaries": crossed,
-        "stage_count": len(crossed),
-        "first_blocked_point": blocked[0].get("blocked_point") if blocked else None,
-        "reached_execution_boundary": any(d.get("boundary") == "execution_boundary" for d in tagged),
-        "contained": bool(blocked) or not any(d.get("boundary") == "execution_boundary" for d in tagged),
-    }
+    live_report = CanaryPropagationReport(
+        injection_point=crossed[0] if crossed else None,
+        crossed_boundaries=crossed,
+        stage_count=len(crossed),
+        first_blocked_point=blocked[0].get("blocked_point") if blocked else None,
+        reached_execution_boundary=any(d.get("boundary") == "execution_boundary" for d in tagged),
+        contained=bool(blocked) or not any(d.get("boundary") == "execution_boundary" for d in tagged),
+    ).model_dump(mode="json")
     merged = dict(summary)
     agentic = dict(merged.get("agentic_security", {}))
     agentic["live_canary_event_total"] = sum(len(d.get("canary_tags", [])) for d in tagged)

--- a/src/redthread/orchestration/runtime_summary.py
+++ b/src/redthread/orchestration/runtime_summary.py
@@ -17,6 +17,39 @@ def _build_agentic_security_summary(state: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def merge_live_canary_report(summary: RuntimeSummary, execution_records: list[Any]) -> RuntimeSummary:
+    """Merge canary containment decisions from live execution records."""
+    decisions = [
+        record.metadata.get("canary_containment")
+        for record in execution_records
+        if getattr(record, "metadata", None) and record.metadata.get("canary_containment")
+    ]
+    tagged = [decision for decision in decisions if decision.get("canary_tags")]
+    if not tagged:
+        return summary
+    blocked = [decision for decision in tagged if decision.get("decision") == "block"]
+    crossed = []
+    for decision in tagged:
+        seam = decision.get("seam")
+        if seam and seam not in crossed:
+            crossed.append(seam)
+    live_report = {
+        "injection_point": crossed[0] if crossed else None,
+        "crossed_boundaries": crossed,
+        "stage_count": len(crossed),
+        "first_blocked_point": blocked[0].get("blocked_point") if blocked else None,
+        "reached_execution_boundary": any(d.get("boundary") == "execution_boundary" for d in tagged),
+        "contained": bool(blocked) or not any(d.get("boundary") == "execution_boundary" for d in tagged),
+    }
+    merged = dict(summary)
+    agentic = dict(merged.get("agentic_security", {}))
+    agentic["live_canary_event_total"] = sum(len(d.get("canary_tags", [])) for d in tagged)
+    agentic["live_canary_report"] = live_report
+    agentic["canary_event_total"] = agentic.get("canary_event_total", 0) + agentic["live_canary_event_total"]
+    merged["agentic_security"] = agentic
+    return merged
+
+
 def build_runtime_summary(state: dict[str, Any]) -> RuntimeSummary:
     """Build a compact operator-facing runtime summary from supervisor state."""
     attack_worker_total = state.get("attack_worker_total", 0)

--- a/src/redthread/orchestration/supervisor.py
+++ b/src/redthread/orchestration/supervisor.py
@@ -70,6 +70,8 @@ class SupervisorState(TypedDict):
     authorization_decision_counts: dict[str, int]
     canary_event_total: int
     canary_report: dict[str, Any]
+    live_canary_event_total: int
+    live_canary_report: dict[str, Any]
     amplification_metrics: dict[str, Any]
     budget_stop_triggered: bool
     untrusted_lineage_action_total: int
@@ -136,6 +138,28 @@ def fan_out_attack_workers(state: SupervisorState) -> list[Send]:
     return sends
 
 
+def _worker_canary_update(
+    outputs: list[dict[str, Any]],
+    existing_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Extract canary reports emitted by workers and merge them for supervisor state."""
+    from redthread.orchestration.runtime_summary import merge_canary_reports
+
+    reports = [existing_report] if existing_report else []
+    reports.extend(
+        output["live_canary_report"]
+        for output in outputs
+        if isinstance(output.get("live_canary_report"), dict)
+    )
+    merged = merge_canary_reports(reports)
+    if not merged:
+        return {}
+    return {
+        "live_canary_report": merged,
+        "live_canary_event_total": merged.get("stage_count", 0),
+    }
+
+
 async def collect_results_node(state: SupervisorState) -> dict[str, Any]:
     """Collect all attack_worker outputs — consolidates fan-out results."""
     logger.info(
@@ -154,6 +178,7 @@ async def collect_results_node(state: SupervisorState) -> dict[str, Any]:
         "errors": errors,
         "attack_worker_total": len(state["attack_results"]),
         "attack_worker_failures": attack_worker_failures,
+        **_worker_canary_update(state["attack_results"]),
     }
 
 
@@ -195,6 +220,7 @@ async def judge_all_results_node(state: SupervisorState) -> dict[str, Any]:
         "errors": errors,
         "judge_worker_total": len(judge_inputs),
         "judge_worker_failures": judge_worker_failures,
+        **_worker_canary_update(judged, state.get("live_canary_report")),
     }
 
 
@@ -271,6 +297,7 @@ async def defense_synthesis_node(state: SupervisorState) -> dict[str, Any]:
         "defense_worker_total": len(defense_inputs),
         "defense_worker_failures": defense_worker_failures,
         "defense_deployments": defense_deployments,
+        **_worker_canary_update(records, state.get("live_canary_report")),
     }
 
 
@@ -426,6 +453,8 @@ class RedThreadSupervisor:
             "authorization_decision_counts": {},
             "canary_event_total": 0,
             "canary_report": {},
+            "live_canary_event_total": 0,
+            "live_canary_report": {},
             "amplification_metrics": {},
             "budget_stop_triggered": False,
             "untrusted_lineage_action_total": 0,

--- a/src/redthread/pyrit_adapters/client.py
+++ b/src/redthread/pyrit_adapters/client.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import replace
 from uuid import uuid4
 
 from redthread.config.settings import RedThreadSettings, TargetBackend
+from redthread.orchestration.canary_containment import evaluate_canary_containment
 from redthread.pyrit_adapters.execution_context import get_execution_recorder
 from redthread.pyrit_adapters.execution_records import (
     ExecutionMetadata,
@@ -60,6 +62,7 @@ class RedThreadTarget:
             conversation_id = str(uuid4())
 
         try:
+            execution_metadata = self._apply_canary_containment(prompt, execution_metadata)
             maybe_intercept_live_execution(execution_metadata)
             message_cls, message_piece_cls, _ = import_pyrit_runtime()
             piece = message_piece_cls(
@@ -94,6 +97,30 @@ class RedThreadTarget:
     ) -> tuple[str, int]:
         response = await self.send(prompt, conversation_id, execution_metadata=execution_metadata)
         return response, (len(prompt) + len(response)) // 4
+
+    def _apply_canary_containment(
+        self,
+        prompt: str,
+        execution_metadata: ExecutionMetadata | None,
+    ) -> ExecutionMetadata | None:
+        if execution_metadata is None:
+            return None
+        if execution_metadata.canary_containment is not None:
+            return execution_metadata
+        decision = evaluate_canary_containment(
+            seam=execution_metadata.seam,
+            prompt=prompt,
+            metadata=execution_metadata.metadata,
+            canary_tags=execution_metadata.canary_tags,
+        )
+        updated = replace(
+            execution_metadata,
+            canary_tags=list(dict.fromkeys([*execution_metadata.canary_tags, *decision.canary_tags])),
+            canary_containment=decision.model_dump(mode="json"),
+        )
+        if decision.blocked:
+            raise RuntimeError(decision.reason)
+        return updated
 
     def close(self) -> None:
         if hasattr(self._target, "dispose_db_engine"):

--- a/src/redthread/pyrit_adapters/controlled.py
+++ b/src/redthread/pyrit_adapters/controlled.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 from redthread.orchestration.models import ActionEnvelope, AuthorizationDecision
-from redthread.pyrit_adapters.targets import RedThreadTarget
+from redthread.pyrit_adapters.targets import (
+    ExecutionMetadata,
+    RedThreadTarget,
+    send_with_execution_metadata,
+)
 from redthread.tools.authorization import authorize_live_action
 from redthread.tools.authorization.models import AuthorizationPolicy
 
@@ -47,4 +51,16 @@ class ControlledLiveAdapter:
             decision = authorize_live_action(action, policies=self._policies)
             if decision.decision.value != "allow":
                 raise LiveAuthorizationInterceptionError(decision)
-        return await self._target.send(prompt, conversation_id)
+        return await send_with_execution_metadata(
+            self._target,
+            prompt=prompt,
+            conversation_id=conversation_id,
+            execution_metadata=ExecutionMetadata(
+                seam="controlled.live_adapter",
+                role="live_adapter",
+                evidence_class="controlled_live_send",
+                authorization_decision=decision.model_dump(mode="json") if action is not None else None,
+                canary_tags=action.canary_tags if action is not None else [],
+                metadata={"approval_id": self._gate.approval_id, "replay_bundle_id": self._gate.replay_bundle_id},
+            ),
+        )

--- a/src/redthread/pyrit_adapters/execution_records.py
+++ b/src/redthread/pyrit_adapters/execution_records.py
@@ -17,6 +17,8 @@ class ExecutionMetadata:
     runtime_mode: str = LIVE_PROVIDER
     conversation_id: str | None = None
     authorization_decision: dict[str, Any] | None = None
+    canary_tags: list[str] = field(default_factory=list)
+    canary_containment: dict[str, Any] | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -57,5 +59,9 @@ def build_execution_record(
         success=success,
         error=error,
         authorization_decision=execution_metadata.authorization_decision,
-        metadata=dict(execution_metadata.metadata),
+        metadata={
+            **dict(execution_metadata.metadata),
+            "canary_tags": list(execution_metadata.canary_tags),
+            "canary_containment": execution_metadata.canary_containment,
+        },
     )

--- a/src/redthread/pyrit_adapters/send_helpers.py
+++ b/src/redthread/pyrit_adapters/send_helpers.py
@@ -60,6 +60,7 @@ def _with_canary_decision(
         prompt=prompt,
         metadata=execution_metadata.metadata,
         canary_tags=execution_metadata.canary_tags,
+        mode=str(execution_metadata.metadata.get("canary_policy_preset", "block_memory_and_outbound")),
     )
     updated_tags = list(dict.fromkeys([*execution_metadata.canary_tags, *decision.canary_tags]))
     updated_metadata = replace(

--- a/src/redthread/pyrit_adapters/send_helpers.py
+++ b/src/redthread/pyrit_adapters/send_helpers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
+from redthread.orchestration.canary_containment import evaluate_canary_containment
 from redthread.pyrit_adapters.execution_records import ExecutionMetadata
+from redthread.pyrit_adapters.interceptors import LiveExecutionInterceptionError
 
 
 async def send_with_execution_metadata(
@@ -13,6 +16,7 @@ async def send_with_execution_metadata(
     execution_metadata: ExecutionMetadata | None = None,
 ) -> str:
     """Call target.send() with execution metadata when the target supports it."""
+    execution_metadata = _with_canary_decision(prompt, execution_metadata)
     try:
         return await target.send(
             prompt=prompt,
@@ -32,6 +36,7 @@ async def send_with_usage_and_execution_metadata(
     conversation_id: str = "",
     execution_metadata: ExecutionMetadata | None = None,
 ) -> tuple[str, int]:
+    execution_metadata = _with_canary_decision(prompt, execution_metadata)
     try:
         return await target.send_with_usage(
             prompt=prompt,
@@ -42,3 +47,26 @@ async def send_with_usage_and_execution_metadata(
         if "execution_metadata" not in str(exc):
             raise
         return await target.send_with_usage(prompt=prompt, conversation_id=conversation_id)
+
+
+def _with_canary_decision(
+    prompt: str,
+    execution_metadata: ExecutionMetadata | None,
+) -> ExecutionMetadata | None:
+    if execution_metadata is None:
+        return None
+    decision = evaluate_canary_containment(
+        seam=execution_metadata.seam,
+        prompt=prompt,
+        metadata=execution_metadata.metadata,
+        canary_tags=execution_metadata.canary_tags,
+    )
+    updated_tags = list(dict.fromkeys([*execution_metadata.canary_tags, *decision.canary_tags]))
+    updated_metadata = replace(
+        execution_metadata,
+        canary_tags=updated_tags,
+        canary_containment=decision.model_dump(mode="json"),
+    )
+    if decision.blocked:
+        raise LiveExecutionInterceptionError(decision.reason)
+    return updated_metadata

--- a/src/redthread/tools/attack_tool.py
+++ b/src/redthread/tools/attack_tool.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from redthread.pyrit_adapters.targets import ExecutionMetadata, send_with_execution_metadata
 from redthread.tools.authorization import authorize_live_action
 from redthread.tools.authorization.tool_context import (
     AUTHORIZATION_ACTION_METADATA_KEY,
@@ -70,9 +71,18 @@ class AttackTool(RedThreadTool[AttackInput]):
         target = build_target(ctx.settings)
 
         try:
-            response = await target.send(
+            response = await send_with_execution_metadata(
+                target,
                 prompt=data.prompt,
                 conversation_id=conversation_id,
+                execution_metadata=ExecutionMetadata(
+                    seam="tool.attack",
+                    role="attack_tool",
+                    evidence_class="live_attack",
+                    authorization_decision=decision.model_dump(mode="json") if decision else None,
+                    canary_tags=action.canary_tags if action is not None else [],
+                    metadata={"campaign_id": ctx.campaign_id, "persona_id": data.persona_id},
+                ),
             )
             meta = {
                 "conversation_id": conversation_id,

--- a/src/redthread/tools/base.py
+++ b/src/redthread/tools/base.py
@@ -113,6 +113,7 @@ class RedThreadTool(ABC, Generic[InputT]):
                 seam=str(ctx.metadata.get("seam", f"tool.{self.name}")),
                 metadata=ctx.metadata,
                 canary_tags=ctx.canary_tags,
+                mode=ctx.settings.canary_policy_preset.value,
             )
             if decision.blocked:
                 return ToolResult.err(

--- a/src/redthread/tools/base.py
+++ b/src/redthread/tools/base.py
@@ -16,6 +16,7 @@ from typing import Any, Generic, TypeVar
 from pydantic import BaseModel
 
 from redthread.config.settings import RedThreadSettings
+from redthread.orchestration.canary_containment import evaluate_canary_containment
 
 InputT = TypeVar("InputT", bound=BaseModel)
 
@@ -28,6 +29,7 @@ class ToolContext:
     campaign_id: str
     dry_run: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
+    canary_tags: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -105,5 +107,17 @@ class RedThreadTool(ABC, Generic[InputT]):
         permission = await self.check_permissions(data, ctx)
         if not permission.allowed:
             return ToolResult.err(f"Permission denied: {permission.reason}")
+
+        if self.is_destructive:
+            decision = evaluate_canary_containment(
+                seam=str(ctx.metadata.get("seam", f"tool.{self.name}")),
+                metadata=ctx.metadata,
+                canary_tags=ctx.canary_tags,
+            )
+            if decision.blocked:
+                return ToolResult.err(
+                    f"Canary containment blocked tool: {decision.reason}",
+                    canary_containment=decision.model_dump(mode="json"),
+                )
 
         return await self.call(data, ctx)

--- a/src/redthread/tools/sandbox_tool.py
+++ b/src/redthread/tools/sandbox_tool.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from redthread.pyrit_adapters.targets import ExecutionMetadata, send_with_execution_metadata
 from redthread.tools.authorization import authorize_live_action
 from redthread.tools.authorization.tool_context import get_authorization_action
 from redthread.tools.base import RedThreadTool, ToolContext, ToolResult
@@ -87,9 +88,18 @@ class SandboxTool(RedThreadTool[SandboxInput]):
         judge = JudgeAgent(ctx.settings)
 
         try:
-            replay_response = await patched_target.send(
+            replay_response = await send_with_execution_metadata(
+                patched_target,
                 prompt=patched_prompt,
                 conversation_id=conversation_id,
+                execution_metadata=ExecutionMetadata(
+                    seam="sandbox.replay",
+                    role="defense_validator",
+                    evidence_class="live_replay",
+                    authorization_decision=decision.model_dump(mode="json") if decision else None,
+                    canary_tags=action.canary_tags if action is not None else [],
+                    metadata={"trace_id": data.trace_id, "rubric_name": data.rubric_name},
+                ),
             )
         except Exception as exc:
             return ToolResult.err(

--- a/tests/test_agentic_replay_promotion.py
+++ b/tests/test_agentic_replay_promotion.py
@@ -91,6 +91,28 @@ def test_replay_bundle_passes_when_controls_match_expectations() -> None:
     assert result["bridge_workflow_context"]["applied_response_binding_count"] == 1
 
 
+def test_replay_bundle_fails_uncontained_live_canary_execution_boundary() -> None:
+    bundle = ReplayBundle(
+        bundle_id="phase-8e-live-canary-fail",
+        traces=[
+            ReplayTrace(
+                trace_id="live-canary-bad",
+                threat="tool_poisoning",
+                live_canary_report={
+                    "contained": False,
+                    "reached_execution_boundary": True,
+                    "crossed_boundaries": ["tool.attack"],
+                },
+            )
+        ],
+    )
+
+    result = evaluate_agentic_promotion(bundle)
+
+    assert result["passed"] is False
+    assert "live-canary-bad:live_canary:uncontained_execution_boundary" in result["failures"]
+
+
 def test_replay_bundle_fails_when_expected_control_is_missing() -> None:
     bundle = ReplayBundle(
         bundle_id="phase-8e-fail",

--- a/tests/test_canary_containment.py
+++ b/tests/test_canary_containment.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
+import pytest
+from pydantic import BaseModel
+
+from redthread.config.settings import RedThreadSettings
+from redthread.orchestration.canary_containment import (
+    CanaryContainmentDecisionType,
+    evaluate_canary_containment,
+)
 from redthread.orchestration.canary_flow import build_canary_report, record_canary_stage
 from redthread.orchestration.graphs.tool_attack_graph import run_tool_attack_scenario
 from redthread.orchestration.models import AmplificationMetrics
-from redthread.orchestration.runtime_summary import build_runtime_summary
+from redthread.orchestration.runtime_summary import build_runtime_summary, merge_live_canary_report
 from redthread.orchestration.scenarios.resource_amplification import (
     run_resource_amplification_scenario,
 )
+from redthread.pyrit_adapters.interceptors import LiveExecutionInterceptionError
+from redthread.pyrit_adapters.targets import ExecutionMetadata, send_with_execution_metadata
 from redthread.telemetry.canaries import inject_canary, merge_canary_tags
 from redthread.telemetry.runtime_budgets import evaluate_runtime_budget
+from redthread.tools.base import RedThreadTool, ToolContext, ToolResult
 from redthread.tools.fixtures.agentic_security import poisoned_compliance_fixture
 
 
@@ -50,6 +61,74 @@ def test_runtime_budget_stops_resource_amplification_case() -> None:
     assert "retry_count" in decision["breaches"]
 
 
+def test_canary_containment_allows_analysis_only_boundary() -> None:
+    decision = evaluate_canary_containment(
+        seam="judge.score",
+        prompt="Evaluate response with CANARY_EXT_TOOL_01 evidence.",
+    )
+
+    assert decision.decision == CanaryContainmentDecisionType.ALLOW
+    assert decision.boundary == "analysis_only"
+    assert decision.canary_tags == ["CANARY_EXT_TOOL_01"]
+
+
+def test_canary_containment_blocks_execution_boundary() -> None:
+    decision = evaluate_canary_containment(
+        seam="tool.attack",
+        prompt="Send this contaminated payload CANARY_EXT_TOOL_01",
+    )
+
+    assert decision.decision == CanaryContainmentDecisionType.BLOCK
+    assert decision.blocked_point == "tool.attack"
+
+
+@pytest.mark.asyncio
+async def test_send_helper_blocks_canary_tagged_execution_boundary() -> None:
+    class DummyTarget:
+        async def send(self, **_: object) -> str:
+            raise AssertionError("target send must not run")
+
+    with pytest.raises(LiveExecutionInterceptionError):
+        await send_with_execution_metadata(
+            DummyTarget(),
+            prompt="contaminated CANARY_EXT_TOOL_01",
+            conversation_id="case-1",
+            execution_metadata=ExecutionMetadata(
+                seam="tool.attack",
+                role="attack_tool",
+                evidence_class="live_attack",
+            ),
+        )
+
+
+class DummyInput(BaseModel):
+    value: str
+
+
+class DummyDestructiveTool(RedThreadTool[DummyInput]):
+    name = "dummy_write"
+    description = "dummy destructive tool"
+    is_destructive = True
+
+    async def call(self, data: DummyInput, ctx: ToolContext) -> ToolResult:
+        return ToolResult.ok(data={"value": data.value})
+
+
+@pytest.mark.asyncio
+async def test_destructive_tool_base_blocks_canary_context() -> None:
+    result = await DummyDestructiveTool().run(
+        DummyInput(value="write"),
+        ToolContext(
+            settings=RedThreadSettings(),
+            campaign_id="camp-1",
+            canary_tags=["CANARY_EXT_TOOL_01"],
+        ),
+    )
+
+    assert result.success is False
+    assert result.metadata["canary_containment"]["decision"] == "block"
+
+
 def test_runtime_summary_surfaces_canary_and_budget_fields() -> None:
     summary = build_runtime_summary(
         {
@@ -64,3 +143,21 @@ def test_runtime_summary_surfaces_canary_and_budget_fields() -> None:
     assert summary["agentic_security"]["canary_event_total"] == 2
     assert summary["agentic_security"]["canary_report"]["reached_execution_boundary"] is True
     assert summary["agentic_security"]["budget_stop_triggered"] is True
+
+
+def test_runtime_summary_merges_live_canary_execution_records() -> None:
+    class Record:
+        metadata = {
+            "canary_containment": {
+                "decision": "allow",
+                "seam": "judge.score",
+                "boundary": "analysis_only",
+                "canary_tags": ["CANARY_EXT_TOOL_01"],
+            }
+        }
+
+    summary = build_runtime_summary({"errors": []})
+    merged = merge_live_canary_report(summary, [Record()])
+
+    assert merged["agentic_security"]["live_canary_event_total"] == 1
+    assert merged["agentic_security"]["live_canary_report"]["contained"] is True

--- a/tests/test_canary_models_policy.py
+++ b/tests/test_canary_models_policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from redthread.config.settings import CanaryPolicyPreset, RedThreadSettings
+from redthread.orchestration.canary_containment import (
+    CanaryContainmentDecisionType,
+    evaluate_canary_containment,
+)
+from redthread.orchestration.canary_flow import (
+    CanaryPropagationReport,
+    CanaryStageEvent,
+    build_typed_canary_report,
+    record_canary_stage,
+)
+from redthread.orchestration.runtime_summary import merge_canary_reports
+from redthread.orchestration.supervisor import _worker_canary_update
+
+
+def test_canary_flow_uses_typed_stage_and_report_models() -> None:
+    stage = CanaryStageEvent.model_validate(
+        record_canary_stage("execution_plan", ["CANARY_EXT_TOOL_01"], blocked=True)
+    )
+    report = build_typed_canary_report([stage])
+
+    assert isinstance(report, CanaryPropagationReport)
+    assert report.first_blocked_point == "execution_plan"
+    assert report.reached_execution_boundary is True
+    assert report.contained is True
+
+
+def test_canary_policy_presets_are_explicit_settings() -> None:
+    settings = RedThreadSettings(canary_policy_preset="monitor_only")
+
+    assert settings.canary_policy_preset == CanaryPolicyPreset.MONITOR_ONLY
+
+
+def test_block_execution_boundary_preset_allows_memory_boundary() -> None:
+    decision = evaluate_canary_containment(
+        seam="memory.write",
+        prompt="store CANARY_EXT_TOOL_01",
+        mode=CanaryPolicyPreset.BLOCK_EXECUTION_BOUNDARY,
+    )
+
+    assert decision.decision == CanaryContainmentDecisionType.ALLOW
+    assert decision.boundary == "memory_write"
+
+
+def test_strict_fail_closed_blocks_shared_state_boundary() -> None:
+    decision = evaluate_canary_containment(
+        seam="supervisor.state",
+        prompt="state CANARY_EXT_TOOL_01",
+        mode=CanaryPolicyPreset.STRICT_FAIL_CLOSED,
+    )
+
+    assert decision.decision == CanaryContainmentDecisionType.BLOCK
+    assert decision.blocked_point == "supervisor.state"
+
+
+def test_supervisor_worker_canary_update_merges_worker_reports() -> None:
+    existing = build_typed_canary_report([
+        CanaryStageEvent(stage="shared_state", canary_tags=["CANARY_EXT_TOOL_01"])
+    ]).model_dump(mode="json")
+    report = build_typed_canary_report([
+        CanaryStageEvent(stage="tool_execution", canary_tags=["CANARY_EXT_TOOL_01"], blocked=True)
+    ]).model_dump(mode="json")
+
+    update = _worker_canary_update([{"live_canary_report": report}], existing)
+
+    assert update["live_canary_event_total"] == 2
+    assert update["live_canary_report"]["crossed_boundaries"] == ["shared_state", "tool_execution"]
+    assert update["live_canary_report"]["first_blocked_point"] == "tool_execution"
+
+
+def test_merge_canary_reports_preserves_uncontained_failure() -> None:
+    merged = merge_canary_reports([
+        {
+            "injection_point": "tool_return",
+            "crossed_boundaries": ["tool_execution"],
+            "stage_count": 1,
+            "reached_execution_boundary": True,
+            "contained": False,
+        }
+    ])
+
+    assert merged["reached_execution_boundary"] is True
+    assert merged["contained"] is False

--- a/tests/test_canary_send_helper.py
+++ b/tests/test_canary_send_helper.py
@@ -45,3 +45,26 @@ async def test_send_helper_allows_analysis_only_canary_and_records_decision() ->
     )
 
     assert response == "judged"
+
+
+@pytest.mark.asyncio
+async def test_send_helper_honors_monitor_only_policy_metadata() -> None:
+    class MonitorTarget:
+        async def send(self, **kwargs: object) -> str:
+            metadata = kwargs["execution_metadata"]
+            assert metadata.canary_containment["decision"] == "allow"
+            assert metadata.canary_containment["reason"] == "monitor-only canary policy"
+            return "sent"
+
+    response = await send_with_execution_metadata(
+        MonitorTarget(),
+        prompt="contaminated CANARY_EXT_TOOL_01",
+        execution_metadata=ExecutionMetadata(
+            seam="tool.attack",
+            role="attack_tool",
+            evidence_class="live_attack",
+            metadata={"canary_policy_preset": "monitor_only"},
+        ),
+    )
+
+    assert response == "sent"

--- a/tests/test_canary_send_helper.py
+++ b/tests/test_canary_send_helper.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from redthread.pyrit_adapters.interceptors import LiveExecutionInterceptionError
+from redthread.pyrit_adapters.targets import ExecutionMetadata, send_with_execution_metadata
+
+
+@pytest.mark.asyncio
+async def test_send_helper_blocks_metadata_only_canary_before_legacy_fallback() -> None:
+    class LegacyTarget:
+        async def send(self, prompt: str, conversation_id: str = "") -> str:
+            raise AssertionError("legacy fallback must not run")
+
+    with pytest.raises(LiveExecutionInterceptionError):
+        await send_with_execution_metadata(
+            LegacyTarget(),
+            prompt="plain prompt",
+            execution_metadata=ExecutionMetadata(
+                seam="attack.target",
+                role="attack_worker",
+                evidence_class="live_attack",
+                metadata={"lineage": {"canary_tags": ["CANARY_EXT_TOOL_01"]}},
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_helper_allows_analysis_only_canary_and_records_decision() -> None:
+    class AnalysisTarget:
+        async def send(self, **kwargs: object) -> str:
+            metadata = kwargs["execution_metadata"]
+            assert metadata.canary_containment["decision"] == "allow"
+            assert metadata.canary_tags == ["CANARY_EXT_TOOL_01"]
+            return "judged"
+
+    response = await send_with_execution_metadata(
+        AnalysisTarget(),
+        prompt="score evidence CANARY_EXT_TOOL_01",
+        execution_metadata=ExecutionMetadata(
+            seam="judge.score",
+            role="judge",
+            evidence_class="analysis_only",
+        ),
+    )
+
+    assert response == "judged"

--- a/tests/test_defense_memory.py
+++ b/tests/test_defense_memory.py
@@ -40,6 +40,33 @@ def test_memory_index_append_and_deduplicate(tmp_path: Path) -> None:
 
 
 
+def test_memory_index_blocks_canary_tagged_memory_write(tmp_path: Path) -> None:
+    settings = make_settings().model_copy(update={"memory_dir": tmp_path})
+    index = MemoryIndex(settings)
+    record = DeploymentRecord(
+        trace_id="trace-canary",
+        guardrail_clause="Do not persist CANARY_EXT_TOOL_01.",
+        classification=VulnerabilityClassification(
+            category="prompt_injection",
+            owasp_ref="LLM01",
+            mitre_atlas_ref="AML.T0054",
+            severity="HIGH",
+            attack_vector="Tool poisoning",
+        ),
+        validation=ValidationResult(
+            passed=True,
+            replay_response="blocked",
+            judge_score=1.0,
+        ),
+        target_model="llama3.2:3b",
+        target_system_prompt_hash="dummyhash",
+        metadata={"canary_tags": ["CANARY_EXT_TOOL_01"]},
+    )
+
+    assert index.append(record) is False
+    assert "trace-canary" not in index.known_trace_ids()
+
+
 def test_memory_index_content_format(tmp_path: Path) -> None:
     settings = make_settings().model_copy(update={"memory_dir": tmp_path})
     index = MemoryIndex(settings)


### PR DESCRIPTION
## Summary
- Adds a central live canary containment guard with typed propagation reports and explicit policy presets.
- Routes protected provider/tool/memory paths through canary-aware checks so tagged content is blocked at execution and memory boundaries by default.
- Surfaces live canary propagation in runtime summaries and promotion gates.
- Adds regression coverage for send-helper, tool, memory, supervisor propagation, policy preset, and promotion-gate behavior.

## Safety boundaries
- Analysis-only seams such as judge scoring can carry tagged evidence.
- Protected execution seams, memory writes, and outbound/target sends block tagged content under the default `block_memory_and_outbound` policy.
- `monitor_only` and `strict_fail_closed` are explicit opt-in modes.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run python -m pytest tests/test_canary_*.py tests/test_agentic_replay_promotion.py tests/test_defense_memory.py tests/test_supervisor.py tests/test_runtime_truth.py tests/test_attack_execution_records.py tests/test_defense_execution_records.py tests/test_live_execution_interceptor.py tests/test_live_execution_truth_smoke.py`
  - Result: 46 passed, 1 skipped
- `uv run ruff check src/redthread/orchestration src/redthread/pyrit_adapters src/redthread/tools src/redthread/memory src/redthread/evaluation tests/test_canary_*.py tests/test_agentic_replay_promotion.py tests/test_defense_memory.py`
  - Result: passed
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src uv run mypy src/redthread/orchestration/canary_flow.py src/redthread/orchestration/canary_containment.py src/redthread/orchestration/runtime_summary.py src/redthread/orchestration/supervisor.py src/redthread/pyrit_adapters/send_helpers.py src/redthread/tools/base.py src/redthread/memory/index.py src/redthread/config/settings.py src/redthread/evaluation/promotion_gate.py src/redthread/evaluation/replay_corpus.py`
  - Result: passed

## Review notes
- Branch was rebased on latest `origin/main` before PR creation.
- Local unrelated files were not included: `.gitignore`, `docs/research/`, `plan-canarytrap.md`.
