### PR TITLE
[codex] Fix adopt-redthread importer module size

### DIFF
--- a/src/redthread/reporting/adopt_redthread_import.py
+++ b/src/redthread/reporting/adopt_redthread_import.py
@@ -7,6 +7,10 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from redthread.reporting.adopt_redthread_pentest_import import (
+    ADOPT_REDTHREAD_PENTEST_CONTEXT_SCHEMA,
+    adopt_redthread_pentest_context_from_payload,
+)
 from redthread.reporting.external_evidence import (
     ExternalEvidenceBundle,
     ExternalEvidenceItem,
@@ -16,7 +20,6 @@ from redthread.reporting.external_evidence import (
 from redthread.reporting.public_artifacts import prompt_safe_json
 
 ADOPT_REDTHREAD_INTENT_EVIDENCE_SCHEMA = "redthread.intent_evidence.v1"
-ADOPT_REDTHREAD_PENTEST_CONTEXT_SCHEMA = "adopt_redthread.pentest_context_package.v0"
 
 
 def import_adopt_redthread_intent_evidence_file(
@@ -78,35 +81,6 @@ def adopt_redthread_intent_evidence_from_payload(payload: object) -> ExternalEvi
     )
 
 
-def adopt_redthread_pentest_context_from_payload(payload: object) -> ExternalEvidenceBundle:
-    """Convert adopt_redthread.pentest_context_package.v0 into weak RedThread evidence."""
-    if not isinstance(payload, Mapping):
-        msg = "adopt-redthread pentest context input must be a JSON object"
-        raise ValueError(msg)
-    package = dict(payload)
-    _validate_pentest_context_boundary(package)
-    items: list[ExternalEvidenceItem] = []
-    for hypothesis in package.get("attack_surface_hypotheses", []):
-        if not isinstance(hypothesis, Mapping):
-            msg = "adopt-redthread pentest hypotheses must be JSON objects"
-            raise ValueError(msg)
-        item = _pentest_hypothesis_item(dict(hypothesis), package)
-        items.append(item)
-    if not items:
-        msg = "adopt-redthread pentest context package must include hypotheses"
-        raise ValueError(msg)
-    return ExternalEvidenceBundle(
-        source=ExternalEvidenceSource.ADOPT_REDTHREAD,
-        items=items,
-        limitations=[
-            "Imported adopt-redthread pentest context is weak planning context, not proof.",
-            "Opt-in auth/write bundles are required before authenticated or state-changing execution.",
-            "JudgeAgent confirmation is required before creating findings or regression cases.",
-            "No raw HAR, URL, header, cookie, body, auth value, or secret is imported.",
-        ],
-    )
-
-
 def _validate_package_boundary(package: dict[str, Any]) -> None:
     if package.get("schema_version") != ADOPT_REDTHREAD_INTENT_EVIDENCE_SCHEMA:
         msg = "unsupported adopt-redthread intent evidence schema"
@@ -150,52 +124,6 @@ def _validate_package_boundary(package: dict[str, Any]) -> None:
         raise ValueError(msg)
 
 
-def _validate_pentest_context_boundary(package: dict[str, Any]) -> None:
-    if package.get("schema_version") != ADOPT_REDTHREAD_PENTEST_CONTEXT_SCHEMA:
-        msg = "unsupported adopt-redthread pentest context schema"
-        raise ValueError(msg)
-    source = package.get("source", {})
-    privacy = package.get("privacy", {})
-    safety = package.get("safety_policy", {})
-    if source.get("raw_artifacts_included") is not False:
-        msg = "adopt-redthread pentest context must not include raw artifacts"
-        raise ValueError(msg)
-    if not privacy.get("sanitized"):
-        msg = "adopt-redthread pentest context must be sanitized"
-        raise ValueError(msg)
-    forbidden_flags = (
-        "raw_har_included",
-        "raw_urls_included",
-        "raw_headers_included",
-        "raw_cookies_included",
-        "raw_bodies_included",
-        "raw_ids_included",
-        "auth_values_included",
-        "secrets_included",
-    )
-    if any(privacy.get(flag) is not False for flag in forbidden_flags):
-        msg = "adopt-redthread pentest context includes forbidden raw/privacy flags"
-        raise ValueError(msg)
-    if safety.get("default_live_execution_allowed") is not False:
-        msg = "adopt-redthread pentest context cannot authorize live execution"
-        raise ValueError(msg)
-    if safety.get("judge_agent_required") is not True:
-        msg = "adopt-redthread pentest context must require JudgeAgent"
-        raise ValueError(msg)
-    for hypothesis in package.get("attack_surface_hypotheses", []):
-        if not isinstance(hypothesis, Mapping):
-            continue
-        if hypothesis.get("not_a_finding") is not True:
-            msg = "adopt-redthread pentest context hypotheses must be not_a_finding"
-            raise ValueError(msg)
-        if hypothesis.get("requires_judge_confirmation") is not True:
-            msg = "adopt-redthread pentest context hypotheses must require JudgeAgent"
-            raise ValueError(msg)
-        if not hypothesis.get("evidence_ids"):
-            msg = "adopt-redthread pentest context hypotheses must cite evidence"
-            raise ValueError(msg)
-
-
 def _evidence_item(evidence: dict[str, Any], package: dict[str, Any]) -> ExternalEvidenceItem:
     source_id = str(evidence.get("id") or evidence.get("source_observation_id") or "adopt-evidence")
     return ExternalEvidenceItem(
@@ -209,28 +137,6 @@ def _evidence_item(evidence: dict[str, Any], package: dict[str, Any]) -> Externa
             "limitations": evidence.get("limitations", []),
             "strength": evidence.get("strength"),
         },
-    )
-
-
-def _pentest_hypothesis_item(hypothesis: dict[str, Any], package: dict[str, Any]) -> ExternalEvidenceItem:
-    source_id = str(hypothesis.get("hypothesis_id") or "adopt-pentest-hypothesis")
-    summary = str(hypothesis.get("summary", ""))
-    return ExternalEvidenceItem(
-        source=ExternalEvidenceSource.ADOPT_REDTHREAD,
-        source_id=source_id,
-        title=f"adopt-redthread pentest context {source_id}",
-        description=summary,
-        detector_hint_context={
-            "adopt_redthread_schema": package.get("schema_version"),
-            "category": hypothesis.get("category"),
-            "subject_id": hypothesis.get("subject_id"),
-            "evidence_ids": hypothesis.get("evidence_ids", []),
-            "missing_context": hypothesis.get("missing_context", []),
-            "requires_judge_confirmation": hypothesis.get("requires_judge_confirmation"),
-            "not_a_finding": hypothesis.get("not_a_finding"),
-            "auth_bundle_required_before_execution": True,
-        },
-        candidate_probe_seed=_probe_seed(source_id, summary, hypothesis) if summary else None,
     )
 
 

--- a/src/redthread/reporting/adopt_redthread_pentest_import.py
+++ b/src/redthread/reporting/adopt_redthread_pentest_import.py
@@ -1,0 +1,118 @@
+"""Importer helpers for adopt-redthread pentest context packages."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from redthread.reporting.external_evidence import (
+    ExternalEvidenceBundle,
+    ExternalEvidenceItem,
+    ExternalEvidenceSource,
+    _probe_seed,
+)
+
+ADOPT_REDTHREAD_PENTEST_CONTEXT_SCHEMA = "adopt_redthread.pentest_context_package.v0"
+
+
+def adopt_redthread_pentest_context_from_payload(payload: object) -> ExternalEvidenceBundle:
+    """Convert adopt_redthread.pentest_context_package.v0 into weak RedThread evidence."""
+    if not isinstance(payload, Mapping):
+        msg = "adopt-redthread pentest context input must be a JSON object"
+        raise ValueError(msg)
+    package = dict(payload)
+    _validate_pentest_context_boundary(package)
+    items: list[ExternalEvidenceItem] = []
+    for hypothesis in package.get("attack_surface_hypotheses", []):
+        if not isinstance(hypothesis, Mapping):
+            msg = "adopt-redthread pentest hypotheses must be JSON objects"
+            raise ValueError(msg)
+        item = _pentest_hypothesis_item(dict(hypothesis), package)
+        items.append(item)
+    if not items:
+        msg = "adopt-redthread pentest context package must include hypotheses"
+        raise ValueError(msg)
+    return ExternalEvidenceBundle(
+        source=ExternalEvidenceSource.ADOPT_REDTHREAD,
+        items=items,
+        limitations=[
+            "Imported adopt-redthread pentest context is weak planning context, not proof.",
+            "Opt-in auth/write bundles are required before authenticated or state-changing execution.",
+            "JudgeAgent confirmation is required before creating findings or regression cases.",
+            "No raw HAR, URL, header, cookie, body, auth value, or secret is imported.",
+        ],
+    )
+
+
+def _validate_pentest_context_boundary(package: dict[str, Any]) -> None:
+    if package.get("schema_version") != ADOPT_REDTHREAD_PENTEST_CONTEXT_SCHEMA:
+        msg = "unsupported adopt-redthread pentest context schema"
+        raise ValueError(msg)
+    source = package.get("source", {})
+    privacy = package.get("privacy", {})
+    safety = package.get("safety_policy", {})
+    if source.get("raw_artifacts_included") is not False:
+        msg = "adopt-redthread pentest context must not include raw artifacts"
+        raise ValueError(msg)
+    if not privacy.get("sanitized"):
+        msg = "adopt-redthread pentest context must be sanitized"
+        raise ValueError(msg)
+    forbidden_flags = (
+        "raw_har_included",
+        "raw_urls_included",
+        "raw_headers_included",
+        "raw_cookies_included",
+        "raw_bodies_included",
+        "raw_ids_included",
+        "auth_values_included",
+        "secrets_included",
+    )
+    if any(privacy.get(flag) is not False for flag in forbidden_flags):
+        msg = "adopt-redthread pentest context includes forbidden raw/privacy flags"
+        raise ValueError(msg)
+    if safety.get("default_live_execution_allowed") is not False:
+        msg = "adopt-redthread pentest context cannot authorize live execution"
+        raise ValueError(msg)
+    if safety.get("judge_agent_required") is not True:
+        msg = "adopt-redthread pentest context must require JudgeAgent"
+        raise ValueError(msg)
+    for hypothesis in package.get("attack_surface_hypotheses", []):
+        if not isinstance(hypothesis, Mapping):
+            continue
+        if hypothesis.get("not_a_finding") is not True:
+            msg = "adopt-redthread pentest context hypotheses must be not_a_finding"
+            raise ValueError(msg)
+        if hypothesis.get("requires_judge_confirmation") is not True:
+            msg = "adopt-redthread pentest context hypotheses must require JudgeAgent"
+            raise ValueError(msg)
+        if not hypothesis.get("evidence_ids"):
+            msg = "adopt-redthread pentest context hypotheses must cite evidence"
+            raise ValueError(msg)
+
+
+def _pentest_hypothesis_item(hypothesis: dict[str, Any], package: dict[str, Any]) -> ExternalEvidenceItem:
+    source_id = str(hypothesis.get("hypothesis_id") or "adopt-pentest-hypothesis")
+    summary = str(hypothesis.get("summary", ""))
+    return ExternalEvidenceItem(
+        source=ExternalEvidenceSource.ADOPT_REDTHREAD,
+        source_id=source_id,
+        title=f"adopt-redthread pentest context {source_id}",
+        description=summary,
+        detector_hint_context={
+            "adopt_redthread_schema": package.get("schema_version"),
+            "category": hypothesis.get("category"),
+            "subject_id": hypothesis.get("subject_id"),
+            "evidence_ids": hypothesis.get("evidence_ids", []),
+            "missing_context": hypothesis.get("missing_context", []),
+            "requires_judge_confirmation": hypothesis.get("requires_judge_confirmation"),
+            "not_a_finding": hypothesis.get("not_a_finding"),
+            "auth_bundle_required_before_execution": True,
+        },
+        candidate_probe_seed=_probe_seed(source_id, summary, hypothesis) if summary else None,
+    )
+
+
+__all__ = [
+    "ADOPT_REDTHREAD_PENTEST_CONTEXT_SCHEMA",
+    "adopt_redthread_pentest_context_from_payload",
+]


### PR DESCRIPTION
## What changed

- Split adopt-redthread pentest context import helpers into `src/redthread/reporting/adopt_redthread_pentest_import.py`.
- Kept the existing public import path stable by re-exporting through `src/redthread/reporting/adopt_redthread_import.py`.

## Why

The daily bug scan found that commit `c0237734` expanded `src/redthread/reporting/adopt_redthread_import.py` to 274 lines. That violates the repo rule that modules stay under 200 lines.

## Impact

No behavior change intended. This is a small separation-of-concerns fix that keeps the importer API stable while bringing both modules under the file-size limit.

## Validation

- `UV_CACHE_DIR=/private/tmp/uv-cache-redthread uv run pytest tests/test_adopt_redthread_intent_import.py tests/test_detector_hints.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache-redthread uv run ruff check src/redthread/reporting/adopt_redthread_import.py src/redthread/reporting/adopt_redthread_pentest_import.py tests/test_adopt_redthread_intent_import.py`